### PR TITLE
Release 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2020-07-13
+### Fixed
+- Keep star character at the end of a line as it can be used to mark as italic.
+
 ## [0.3.0] - 2020-03-01
 ### Changed
 - Information is now stored without star, space or caret at start or end of line.
@@ -22,7 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/Colin-b/keepachangelog/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/Colin-b/keepachangelog/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/Colin-b/keepachangelog/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/Colin-b/keepachangelog/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/Colin-b/keepachangelog/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/Colin-b/keepachangelog/compare/v0.0.1...v0.1.0

--- a/keepachangelog/_changelog.py
+++ b/keepachangelog/_changelog.py
@@ -47,7 +47,7 @@ def is_information(line: str) -> bool:
 
 
 def add_information(category: List[str], line: str):
-    category.append(line.strip(" *-"))
+    category.append(line.lstrip(" *-").rstrip(" -"))
 
 
 def to_dict(changelog_path: str, *, show_unreleased: bool = False) -> Dict[str, dict]:

--- a/keepachangelog/version.py
+++ b/keepachangelog/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.3.0"
+__version__ = "0.3.1"

--- a/tests/test_changelog_unreleased.py
+++ b/tests/test_changelog_unreleased.py
@@ -49,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [1.1.0] - 2018-05-31
 ### Changed
 - Enhancement 1 (1.1.0)
-- sub enhancement 1
+- sub *enhancement 1*
 - sub enhancement 2
 - Enhancement 2 (1.1.0)
 
@@ -96,7 +96,7 @@ def test_changelog_with_versions_and_all_categories(changelog):
             "release_date": "2018-05-31",
             "changed": [
                 "Enhancement 1 (1.1.0)",
-                "sub enhancement 1",
+                "sub *enhancement 1*",
                 "sub enhancement 2",
                 "Enhancement 2 (1.1.0)",
             ],


### PR DESCRIPTION
### Fixed
- Keep star character at the end of a line as it can be used to mark as italic.
