### PR TITLE
parse from either a file or an io buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Allow to parse from either a file path or an io buffer.
 
 ## [0.4.0] - 2020-09-21
 ### Added

--- a/keepachangelog/_changelog.py
+++ b/keepachangelog/_changelog.py
@@ -1,5 +1,6 @@
+import io
 import re
-from typing import Dict, List
+from typing import Dict, List, Union
 
 # Release pattern should match lines like: "## [0.0.1] - 2020-12-31" or ## [Unreleased]
 release_pattern = re.compile(r"^## \[(.*)\](?: - (.*))?$")
@@ -50,9 +51,11 @@ def add_information(category: List[str], line: str):
     category.append(line.lstrip(" *-").rstrip(" -"))
 
 
-def to_dict(changelog_path: str, *, show_unreleased: bool = False) -> Dict[str, dict]:
-    changes = {}
-    with open(changelog_path) as change_log:
+def to_dict(
+    changelog_path: Union[str, io.TextIOBase], *, show_unreleased: bool = False
+) -> Dict[str, dict]:
+    def _read(change_log: Union[str, io.TextIOBase]):
+        changes: dict = {}
         release = {}
         category = []
         for line in change_log:
@@ -65,4 +68,10 @@ def to_dict(changelog_path: str, *, show_unreleased: bool = False) -> Dict[str, 
             elif is_information(line):
                 add_information(category, line)
 
-    return changes
+        return changes
+
+    if isinstance(changelog_path, str):
+        with open(changelog_path) as change_log:
+            return _read(change_log)
+    else:
+        return _read(changelog_path)

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,3 +1,4 @@
+import io
 import os
 import os.path
 
@@ -5,6 +6,48 @@ import pytest
 
 import keepachangelog
 
+changelog_dict = {
+        "1.2.0": {
+            "added": [
+                "Enhancement 1",
+                "sub enhancement 1",
+                "sub enhancement 2",
+                "Enhancement 2",
+            ],
+            "changed": ["Release note 1.", "Release note 2."],
+            "deprecated": ["Deprecated feature 1", "Future removal 2"],
+            "fixed": ["Bug fix 1", "sub bug 1", "sub bug 2", "Bug fix 2"],
+            "release_date": "2018-06-01",
+            "removed": ["Deprecated feature 2", "Future removal 1"],
+            "security": ["Known issue 1", "Known issue 2"],
+            "version": "1.2.0",
+        },
+        "1.1.0": {
+            "changed": [
+                "Enhancement 1 (1.1.0)",
+                "sub enhancement 1",
+                "sub enhancement 2",
+                "Enhancement 2 (1.1.0)",
+            ],
+            "release_date": "2018-05-31",
+            "version": "1.1.0",
+        },
+        "1.0.1": {
+            "fixed": [
+                "Bug fix 1 (1.0.1)",
+                "sub bug 1",
+                "sub bug 2",
+                "Bug fix 2 (1.0.1)",
+            ],
+            "release_date": "2018-05-31",
+            "version": "1.0.1",
+        },
+        "1.0.0": {
+            "deprecated": ["Known issue 1 (1.0.0)", "Known issue 2 (1.0.0)"],
+            "release_date": "2017-04-10",
+            "version": "1.0.0",
+        },
+    }
 
 @pytest.fixture
 def changelog(tmpdir):
@@ -77,45 +120,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 def test_changelog_with_versions_and_all_categories(changelog):
-    assert keepachangelog.to_dict(changelog) == {
-        "1.2.0": {
-            "added": [
-                "Enhancement 1",
-                "sub enhancement 1",
-                "sub enhancement 2",
-                "Enhancement 2",
-            ],
-            "changed": ["Release note 1.", "Release note 2."],
-            "deprecated": ["Deprecated feature 1", "Future removal 2"],
-            "fixed": ["Bug fix 1", "sub bug 1", "sub bug 2", "Bug fix 2"],
-            "release_date": "2018-06-01",
-            "removed": ["Deprecated feature 2", "Future removal 1"],
-            "security": ["Known issue 1", "Known issue 2"],
-            "version": "1.2.0",
-        },
-        "1.1.0": {
-            "changed": [
-                "Enhancement 1 (1.1.0)",
-                "sub enhancement 1",
-                "sub enhancement 2",
-                "Enhancement 2 (1.1.0)",
-            ],
-            "release_date": "2018-05-31",
-            "version": "1.1.0",
-        },
-        "1.0.1": {
-            "fixed": [
-                "Bug fix 1 (1.0.1)",
-                "sub bug 1",
-                "sub bug 2",
-                "Bug fix 2 (1.0.1)",
-            ],
-            "release_date": "2018-05-31",
-            "version": "1.0.1",
-        },
-        "1.0.0": {
-            "deprecated": ["Known issue 1 (1.0.0)", "Known issue 2 (1.0.0)"],
-            "release_date": "2017-04-10",
-            "version": "1.0.0",
-        },
-    }
+    assert keepachangelog.to_dict(changelog) == changelog_dict
+
+def test_changelog_with_versions_and_all_categories_iobase(changelog):
+
+    buffer = io.StringIO(open(changelog).read())
+
+    assert keepachangelog.to_dict(buffer) == changelog_dict
+
+    with pytest.raises(AssertionError):
+        assert keepachangelog.to_dict(buffer) == changelog_dict
+
+    buffer.seek(0)
+    assert keepachangelog.to_dict(buffer) == changelog_dict


### PR DESCRIPTION
Hello! For a downstream project I maintain I'd need to parse changelog from either a file or from stdin, so I've implemented such a possibility in the most unobtrusive manner and hopefully you can consider it!

It keeps the correct context manager design choice when we work w/ a file, instead it does not close the file-like buffer so callers can seek() and do other stuff with their standard input.
What do you think? Thank you, regards!