### PR TITLE
Allow to add a release

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
   - repo: https://github.com/psf/black
-    rev: master
+    rev: 20.8b1
     hooks:
       - id: black

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 install:
   - pip install .[testing]
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `keepachangelog.release` function to guess new version number based on `Unreleased` section.
 
 ## [0.4.0] - 2020-09-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- `keepachangelog.release` function to guess new version number based on `Unreleased` section.
+- `keepachangelog.release` function to guess new version number based on `Unreleased` section, update changelog and return new version number.
 
 ## [0.4.0] - 2020-09-21
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h2 align="center">Convert changelog into dict</h2>
+<h2 align="center">Manipulate keep a changelog files</h2>
 
 <p align="center">
 <a href="https://pypi.org/project/keepachangelog/"><img alt="pypi version" src="https://img.shields.io/pypi/v/keepachangelog"></a>
@@ -9,7 +9,15 @@
 <a href="https://pypi.org/project/keepachangelog/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/keepachangelog"></a>
 </p>
 
-Convert changelog markdown file following [keep a changelog](https://keepachangelog.com/en/1.0.0/) format into python dict.
+* [Convert to dict](#convert-changelog-to-dict)
+* [Release a new version](#release)
+* [Add changelog retrieval REST API endpoint](#endpoint)
+  * [Starlette](#starlette)
+  * [Flask-RestX](#flask-restx)
+
+## Convert changelog to dict
+
+Convert changelog markdown file following [keep a changelog](https://keepachangelog.com/en/1.1.0/) format into python dict.
 
 ```python
 import keepachangelog
@@ -55,7 +63,7 @@ For a markdown file with the following content:
 # Changelog
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
@@ -127,9 +135,13 @@ new_version = keepachangelog.release("path/to/CHANGELOG.md")
 
 This will:
 * Guess the new version number and return it:
-  * TODO explain how version is guessed.
+  * `Removed` or `Changed` sections will be considered as breaking changes, thus incrementing the major version.
+  * If the only section is `Fixed`, only patch will be incremented.
+  * Otherwise, minor will be incremented.
 * Update changelog.
-  * TODO explain what is performed.
+  * Unreleased section content will be moved into a new section.
+  * `[Unreleased]` link will be updated.
+  * New link will be created corresponding to the new section (based on the format of the Unreleased link).
 
 ## Endpoint
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 <p align="center">
 <a href="https://pypi.org/project/keepachangelog/"><img alt="pypi version" src="https://img.shields.io/pypi/v/keepachangelog"></a>
-<a href="https://travis-ci.org/Colin-b/keepachangelog"><img alt="Build status" src="https://api.travis-ci.org/Colin-b/keepachangelog.svg?branch=master"></a>
-<a href="https://travis-ci.org/Colin-b/keepachangelog"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
+<a href="https://travis-ci.com/Colin-b/keepachangelog"><img alt="Build status" src="https://api.travis-ci.com/Colin-b/keepachangelog.svg?branch=master"></a>
+<a href="https://travis-ci.com/Colin-b/keepachangelog"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://travis-ci.org/Colin-b/keepachangelog"><img alt="Number of tests" src="https://img.shields.io/badge/tests-14 passed-blue"></a>
+<a href="https://travis-ci.com/Colin-b/keepachangelog"><img alt="Number of tests" src="https://img.shields.io/badge/tests-22 passed-blue"></a>
 <a href="https://pypi.org/project/keepachangelog/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/keepachangelog"></a>
 </p>
 
@@ -114,6 +114,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 `show_unreleased` parameter can be specified in order to include `Unreleased` section information.
 Note that `release_date` will be set to None in such as case.
+
+## Release
+
+You can create a new release by using `keepachangelog.release` function.
+
+```python
+import keepachangelog
+
+new_version = keepachangelog.release("path/to/CHANGELOG.md")
+```
+
+This will:
+* Guess the new version number and return it:
+  * TODO explain how version is guessed.
+* Update changelog.
+  * TODO explain what is performed.
 
 ## Endpoint
 

--- a/keepachangelog/__init__.py
+++ b/keepachangelog/__init__.py
@@ -1,2 +1,2 @@
 from keepachangelog.version import __version__
-from keepachangelog._changelog import to_dict
+from keepachangelog._changelog import to_dict, release

--- a/keepachangelog/_changelog.py
+++ b/keepachangelog/_changelog.py
@@ -95,17 +95,18 @@ def release_version(
             # Add new version link and update Unreleased link
             elif unreleased_link_pattern.fullmatch(line):
                 unreleased_compare_pattern = re.fullmatch(
-                    "^.*/(.*)...HEAD.*$", line, re.DOTALL
+                    r"^.*/(.*)\.\.\.(\w*).*$", line, re.DOTALL
                 )
-                # Unreleased link compare previous version to HEAD
+                # Unreleased link compare previous version to HEAD (unreleased tag)
                 if unreleased_compare_pattern:
                     new_unreleased_link = line.replace(current_version, new_version)
                     lines.append(new_unreleased_link)
                     current_tag = unreleased_compare_pattern.group(1)
+                    unreleased_tag = unreleased_compare_pattern.group(2)
                     new_tag = current_tag.replace(current_version, new_version)
                     lines.append(
                         line.replace(new_version, current_version)
-                        .replace("HEAD", new_tag)
+                        .replace(unreleased_tag, new_tag)
                         .replace("Unreleased", new_version)
                     )
                 # Consider that there is no way to know how to create a link to compare versions

--- a/keepachangelog/_changelog.py
+++ b/keepachangelog/_changelog.py
@@ -1,6 +1,8 @@
 import re
 from typing import Dict, List
 
+from keepachangelog._versioning import guess_unreleased_version
+
 # Release pattern should match lines like: "## [0.0.1] - 2020-12-31" or ## [Unreleased]
 release_pattern = re.compile(r"^## \[(.*)\](?: - (.*))?$")
 
@@ -66,3 +68,10 @@ def to_dict(changelog_path: str, *, show_unreleased: bool = False) -> Dict[str, 
                 add_information(category, line)
 
     return changes
+
+
+def release(changelog_path: str) -> str:
+    changelog = to_dict(changelog_path, show_unreleased=True)
+    current_version, new_version = guess_unreleased_version(changelog)
+
+    return new_version

--- a/keepachangelog/_versioning.py
+++ b/keepachangelog/_versioning.py
@@ -1,0 +1,68 @@
+import re
+from typing import Tuple, Optional
+
+
+def contains_breaking_changes(unreleased: dict) -> bool:
+    return "removed" in unreleased or "changed" in unreleased
+
+
+def only_contains_bug_fixes(unreleased: dict) -> bool:
+    # unreleased contains at least 2 entries: version and release_date
+    return "fixed" in unreleased and len(unreleased) == 3
+
+
+def bump_major(version: str) -> str:
+    major, *_ = to_semantic(version)
+    return from_semantic(major + 1, 0, 0)
+
+
+def bump_minor(version: str) -> str:
+    major, minor, _ = to_semantic(version)
+    return from_semantic(major, minor + 1, 0)
+
+
+def bump_patch(version: str) -> str:
+    major, minor, patch = to_semantic(version)
+    return from_semantic(major, minor, patch + 1)
+
+
+def bump(unreleased: dict, version: str) -> str:
+    if contains_breaking_changes(unreleased):
+        return bump_major(version)
+    if only_contains_bug_fixes(unreleased):
+        return bump_patch(version)
+    return bump_minor(version)
+
+
+def actual_version(changelog: dict) -> Optional[str]:
+    versions = sorted(changelog.keys())
+    current_version = versions.pop() if versions else None
+    while "Unreleased" == current_version:
+        current_version = versions.pop() if versions else None
+    return current_version
+
+
+def guess_unreleased_version(changelog: dict) -> Tuple[Optional[str], str]:
+    unreleased = changelog.get("Unreleased", {})
+    if not unreleased:
+        raise Exception(
+            "Unable to guess unreleased version because there is not Unreleased section within changelog."
+        )
+
+    version = actual_version(changelog)
+    return version, bump(unreleased, version)
+
+
+def to_semantic(version: Optional[str]) -> Tuple[int, int, int]:
+    if not version:
+        return 0, 0, 0
+
+    match = re.search(r"(\d+)\.(\d+)\.(\d+)", version)
+    if match:
+        return int(match.group(1)), int(match.group(2)), int(match.group(3))
+
+    raise Exception(f"{version} is not following semantic versioning.")
+
+
+def from_semantic(major: int, minor: int, patch: int) -> str:
+    return f"{major}.{minor}.{patch}"

--- a/keepachangelog/_versioning.py
+++ b/keepachangelog/_versioning.py
@@ -44,9 +44,9 @@ def actual_version(changelog: dict) -> Optional[str]:
 
 def guess_unreleased_version(changelog: dict) -> Tuple[Optional[str], str]:
     unreleased = changelog.get("Unreleased", {})
-    if not unreleased:
+    if not unreleased or len(unreleased) < 3:
         raise Exception(
-            "Unable to guess unreleased version because there is not Unreleased section within changelog."
+            "Release content must be provided within changelog Unreleased section."
         )
 
     version = actual_version(changelog)

--- a/keepachangelog/_versioning.py
+++ b/keepachangelog/_versioning.py
@@ -53,11 +53,15 @@ def guess_unreleased_version(changelog: dict) -> Tuple[Optional[str], str]:
     return version, bump(unreleased, version)
 
 
+# Semantic versioning pattern should match version like 1.2.3"
+version_pattern = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+
+
 def to_semantic(version: Optional[str]) -> Tuple[int, int, int]:
     if not version:
         return 0, 0, 0
 
-    match = re.search(r"(\d+)\.(\d+)\.(\d+)", version)
+    match = version_pattern.fullmatch(version)
     if match:
         return int(match.group(1)), int(match.group(2)), int(match.group(3))
 

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
         "Topic :: Software Development :: Build Tools",
     ],
     keywords=["changelog", "CHANGELOG.md", "markdown"],

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     maintainer="Colin Bounouar",
     maintainer_email="colin.bounouar.dev@gmail.com",
     url="https://colin-b.github.io/keepachangelog/",
-    description="Convert changelog into dict.",
+    description="Manipulate keep a changelog files.",
     long_description=long_description,
     long_description_content_type="text/markdown",
     download_url="https://pypi.org/project/keepachangelog/",

--- a/tests/test_changelog_release.py
+++ b/tests/test_changelog_release.py
@@ -1,0 +1,369 @@
+import os
+import os.path
+
+import pytest
+
+import keepachangelog
+
+
+@pytest.fixture
+def major_changelog(tmpdir):
+    changelog_file_path = os.path.join(tmpdir, "MAJOR_CHANGELOG.md")
+    with open(changelog_file_path, "wt") as file:
+        file.write(
+            """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Changed
+- Release note 1. 
+* Release note 2.
+
+### Added
+- Enhancement 1
+ - sub enhancement 1 
+ * sub enhancement 2
+- Enhancement 2
+
+### Fixed
+- Bug fix 1
+ - sub bug 1
+ * sub bug 2
+- Bug fix 2
+
+### Security
+* Known issue 1
+- Known issue 2
+
+### Deprecated
+- Deprecated feature 1 
+* Future removal 2
+
+### Removed
+- Deprecated feature 2
+* Future removal 1 
+
+## [1.1.0] - 2018-05-31
+### Changed
+- Enhancement 1 (1.1.0)
+- sub *enhancement 1*
+- sub enhancement 2
+- Enhancement 2 (1.1.0)
+
+## [1.0.1] - 2018-05-31
+### Fixed
+- Bug fix 1 (1.0.1)
+- sub bug 1
+- sub bug 2
+- Bug fix 2 (1.0.1)
+
+## [1.0.0] - 2017-04-10
+### Deprecated
+- Known issue 1 (1.0.0)
+- Known issue 2 (1.0.0)
+
+[Unreleased]: https://github.test_url/test_project/compare/v1.1.0...HEAD
+[1.1.0]: https://github.test_url/test_project/compare/v1.0.1...v1.1.0
+[1.0.1]: https://github.test_url/test_project/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.test_url/test_project/releases/tag/v1.0.0
+"""
+        )
+    return changelog_file_path
+
+
+@pytest.fixture
+def minor_changelog(tmpdir):
+    changelog_file_path = os.path.join(tmpdir, "MINOR_CHANGELOG.md")
+    with open(changelog_file_path, "wt") as file:
+        file.write(
+            """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Enhancement 1
+ - sub enhancement 1 
+ * sub enhancement 2
+- Enhancement 2
+
+### Fixed
+- Bug fix 1
+ - sub bug 1
+ * sub bug 2
+- Bug fix 2
+
+### Security
+* Known issue 1
+- Known issue 2
+
+### Deprecated
+- Deprecated feature 1 
+* Future removal 2
+
+## [1.1.0] - 2018-05-31
+### Changed
+- Enhancement 1 (1.1.0)
+- sub *enhancement 1*
+- sub enhancement 2
+- Enhancement 2 (1.1.0)
+
+## [1.0.1] - 2018-05-31
+### Fixed
+- Bug fix 1 (1.0.1)
+- sub bug 1
+- sub bug 2
+- Bug fix 2 (1.0.1)
+
+## [1.0.0] - 2017-04-10
+### Deprecated
+- Known issue 1 (1.0.0)
+- Known issue 2 (1.0.0)
+
+[Unreleased]: https://github.test_url/test_project/compare/v1.1.0...HEAD
+[1.1.0]: https://github.test_url/test_project/compare/v1.0.1...v1.1.0
+[1.0.1]: https://github.test_url/test_project/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.test_url/test_project/releases/tag/v1.0.0
+"""
+        )
+    return changelog_file_path
+
+
+@pytest.fixture
+def patch_changelog(tmpdir):
+    changelog_file_path = os.path.join(tmpdir, "PATCH_CHANGELOG.md")
+    with open(changelog_file_path, "wt") as file:
+        file.write(
+            """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Fixed
+- Bug fix 1
+ - sub bug 1
+ * sub bug 2
+- Bug fix 2
+
+## [1.1.0] - 2018-05-31
+### Changed
+- Enhancement 1 (1.1.0)
+- sub *enhancement 1*
+- sub enhancement 2
+- Enhancement 2 (1.1.0)
+
+## [1.0.1] - 2018-05-31
+### Fixed
+- Bug fix 1 (1.0.1)
+- sub bug 1
+- sub bug 2
+- Bug fix 2 (1.0.1)
+
+## [1.0.0] - 2017-04-10
+### Deprecated
+- Known issue 1 (1.0.0)
+- Known issue 2 (1.0.0)
+
+[Unreleased]: https://github.test_url/test_project/compare/v1.1.0...HEAD
+[1.1.0]: https://github.test_url/test_project/compare/v1.0.1...v1.1.0
+[1.0.1]: https://github.test_url/test_project/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.test_url/test_project/releases/tag/v1.0.0
+"""
+        )
+    return changelog_file_path
+
+
+@pytest.fixture
+def first_major_changelog(tmpdir):
+    changelog_file_path = os.path.join(tmpdir, "FIRST_MAJOR_CHANGELOG.md")
+    with open(changelog_file_path, "wt") as file:
+        file.write(
+            """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Changed
+- Release note 1. 
+* Release note 2.
+
+### Added
+- Enhancement 1
+ - sub enhancement 1 
+ * sub enhancement 2
+- Enhancement 2
+
+### Fixed
+- Bug fix 1
+ - sub bug 1
+ * sub bug 2
+- Bug fix 2
+
+### Security
+* Known issue 1
+- Known issue 2
+
+### Deprecated
+- Deprecated feature 1 
+* Future removal 2
+
+### Removed
+- Deprecated feature 2
+* Future removal 1 
+
+[Unreleased]: https://github.test_url/test_project
+"""
+        )
+    return changelog_file_path
+
+
+@pytest.fixture
+def first_minor_changelog(tmpdir):
+    changelog_file_path = os.path.join(tmpdir, "FIRST_MINOR_CHANGELOG.md")
+    with open(changelog_file_path, "wt") as file:
+        file.write(
+            """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Added
+- Enhancement 1
+ - sub enhancement 1 
+ * sub enhancement 2
+- Enhancement 2
+
+### Fixed
+- Bug fix 1
+ - sub bug 1
+ * sub bug 2
+- Bug fix 2
+
+### Security
+* Known issue 1
+- Known issue 2
+
+### Deprecated
+- Deprecated feature 1 
+* Future removal 2
+
+[Unreleased]: https://github.test_url/test_project
+"""
+        )
+    return changelog_file_path
+
+
+@pytest.fixture
+def first_patch_changelog(tmpdir):
+    changelog_file_path = os.path.join(tmpdir, "FIRST_PATCH_CHANGELOG.md")
+    with open(changelog_file_path, "wt") as file:
+        file.write(
+            """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Fixed
+- Bug fix 1
+ - sub bug 1
+ * sub bug 2
+- Bug fix 2
+
+[Unreleased]: https://github.test_url/test_project
+"""
+        )
+    return changelog_file_path
+
+
+@pytest.fixture
+def empty_changelog(tmpdir):
+    changelog_file_path = os.path.join(tmpdir, "EMPTY_CHANGELOG.md")
+    with open(changelog_file_path, "wt") as file:
+        file.write(
+            """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+"""
+        )
+    return changelog_file_path
+
+
+@pytest.fixture
+def non_semantic_changelog(tmpdir):
+    changelog_file_path = os.path.join(tmpdir, "NON_SEMANTIC_CHANGELOG.md")
+    with open(changelog_file_path, "wt") as file:
+        file.write(
+            """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [20180531] - 2018-05-31
+### Changed
+- Enhancement 1 (1.1.0)
+- sub *enhancement 1*
+- sub enhancement 2
+- Enhancement 2 (1.1.0)
+
+[Unreleased]: https://github.test_url/test_project/compare/v20180531...HEAD
+[20180531]: https://github.test_url/test_project/releases/tag/v20180531
+"""
+        )
+    return changelog_file_path
+
+
+def test_major_release(major_changelog):
+    assert keepachangelog.release(major_changelog) == "2.0.0"
+
+
+def test_minor_release(minor_changelog):
+    assert keepachangelog.release(minor_changelog) == "1.2.0"
+
+
+def test_patch_release(patch_changelog):
+    assert keepachangelog.release(patch_changelog) == "1.1.1"
+
+
+def test_first_major_release(first_major_changelog):
+    assert keepachangelog.release(first_major_changelog) == "1.0.0"
+
+
+def test_first_minor_release(first_minor_changelog):
+    assert keepachangelog.release(first_minor_changelog) == "0.1.0"
+
+
+def test_first_patch_release(first_patch_changelog):
+    assert keepachangelog.release(first_patch_changelog) == "0.0.1"
+
+
+def test_empty_release(empty_changelog):
+    with pytest.raises(Exception) as exception_info:
+        keepachangelog.release(empty_changelog)
+    assert (
+        str(exception_info.value)
+        == "Unable to guess unreleased version because there is not Unreleased section within changelog."
+    )
+
+
+def test_non_semantic_release(non_semantic_changelog):
+    with pytest.raises(Exception) as exception_info:
+        keepachangelog.release(non_semantic_changelog)
+    assert str(exception_info.value) == "20180531 is not following semantic versioning."

--- a/tests/test_changelog_release.py
+++ b/tests/test_changelog_release.py
@@ -332,26 +332,296 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 def test_major_release(major_changelog):
     assert keepachangelog.release(major_changelog) == "2.0.0"
+    with open(major_changelog) as file:
+        assert (
+            file.read()
+            == """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.0.0] - 2021-03-19
+### Changed
+- Release note 1. 
+* Release note 2.
+
+### Added
+- Enhancement 1
+ - sub enhancement 1 
+ * sub enhancement 2
+- Enhancement 2
+
+### Fixed
+- Bug fix 1
+ - sub bug 1
+ * sub bug 2
+- Bug fix 2
+
+### Security
+* Known issue 1
+- Known issue 2
+
+### Deprecated
+- Deprecated feature 1 
+* Future removal 2
+
+### Removed
+- Deprecated feature 2
+* Future removal 1 
+
+## [1.1.0] - 2018-05-31
+### Changed
+- Enhancement 1 (1.1.0)
+- sub *enhancement 1*
+- sub enhancement 2
+- Enhancement 2 (1.1.0)
+
+## [1.0.1] - 2018-05-31
+### Fixed
+- Bug fix 1 (1.0.1)
+- sub bug 1
+- sub bug 2
+- Bug fix 2 (1.0.1)
+
+## [1.0.0] - 2017-04-10
+### Deprecated
+- Known issue 1 (1.0.0)
+- Known issue 2 (1.0.0)
+
+[Unreleased]: https://github.test_url/test_project/compare/v2.0.0...HEAD
+[2.0.0]: https://github.test_url/test_project/compare/v1.1.0...v2.0.0
+[1.1.0]: https://github.test_url/test_project/compare/v1.0.1...v1.1.0
+[1.0.1]: https://github.test_url/test_project/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.test_url/test_project/releases/tag/v1.0.0
+"""
+        )
 
 
 def test_minor_release(minor_changelog):
     assert keepachangelog.release(minor_changelog) == "1.2.0"
+    with open(minor_changelog) as file:
+        assert (
+            file.read()
+            == """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.2.0] - 2021-03-19
+### Added
+- Enhancement 1
+ - sub enhancement 1 
+ * sub enhancement 2
+- Enhancement 2
+
+### Fixed
+- Bug fix 1
+ - sub bug 1
+ * sub bug 2
+- Bug fix 2
+
+### Security
+* Known issue 1
+- Known issue 2
+
+### Deprecated
+- Deprecated feature 1 
+* Future removal 2
+
+## [1.1.0] - 2018-05-31
+### Changed
+- Enhancement 1 (1.1.0)
+- sub *enhancement 1*
+- sub enhancement 2
+- Enhancement 2 (1.1.0)
+
+## [1.0.1] - 2018-05-31
+### Fixed
+- Bug fix 1 (1.0.1)
+- sub bug 1
+- sub bug 2
+- Bug fix 2 (1.0.1)
+
+## [1.0.0] - 2017-04-10
+### Deprecated
+- Known issue 1 (1.0.0)
+- Known issue 2 (1.0.0)
+
+[Unreleased]: https://github.test_url/test_project/compare/v1.2.0...HEAD
+[1.2.0]: https://github.test_url/test_project/compare/v1.1.0...v1.2.0
+[1.1.0]: https://github.test_url/test_project/compare/v1.0.1...v1.1.0
+[1.0.1]: https://github.test_url/test_project/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.test_url/test_project/releases/tag/v1.0.0
+"""
+        )
 
 
 def test_patch_release(patch_changelog):
     assert keepachangelog.release(patch_changelog) == "1.1.1"
+    with open(patch_changelog) as file:
+        assert (
+            file.read()
+            == """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.1.1] - 2021-03-19
+### Fixed
+- Bug fix 1
+ - sub bug 1
+ * sub bug 2
+- Bug fix 2
+
+## [1.1.0] - 2018-05-31
+### Changed
+- Enhancement 1 (1.1.0)
+- sub *enhancement 1*
+- sub enhancement 2
+- Enhancement 2 (1.1.0)
+
+## [1.0.1] - 2018-05-31
+### Fixed
+- Bug fix 1 (1.0.1)
+- sub bug 1
+- sub bug 2
+- Bug fix 2 (1.0.1)
+
+## [1.0.0] - 2017-04-10
+### Deprecated
+- Known issue 1 (1.0.0)
+- Known issue 2 (1.0.0)
+
+[Unreleased]: https://github.test_url/test_project/compare/v1.1.1...HEAD
+[1.1.1]: https://github.test_url/test_project/compare/v1.1.0...v1.1.1
+[1.1.0]: https://github.test_url/test_project/compare/v1.0.1...v1.1.0
+[1.0.1]: https://github.test_url/test_project/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.test_url/test_project/releases/tag/v1.0.0
+"""
+        )
 
 
 def test_first_major_release(first_major_changelog):
     assert keepachangelog.release(first_major_changelog) == "1.0.0"
+    with open(first_major_changelog) as file:
+        assert (
+            file.read()
+            == """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0] - 2021-03-19
+### Changed
+- Release note 1. 
+* Release note 2.
+
+### Added
+- Enhancement 1
+ - sub enhancement 1 
+ * sub enhancement 2
+- Enhancement 2
+
+### Fixed
+- Bug fix 1
+ - sub bug 1
+ * sub bug 2
+- Bug fix 2
+
+### Security
+* Known issue 1
+- Known issue 2
+
+### Deprecated
+- Deprecated feature 1 
+* Future removal 2
+
+### Removed
+- Deprecated feature 2
+* Future removal 1 
+
+[Unreleased]: https://github.test_url/test_project
+[1.0.0]: https://github.test_url/test_project
+"""
+        )
 
 
 def test_first_minor_release(first_minor_changelog):
     assert keepachangelog.release(first_minor_changelog) == "0.1.0"
+    with open(first_minor_changelog) as file:
+        assert (
+            file.read()
+            == """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2021-03-19
+### Added
+- Enhancement 1
+ - sub enhancement 1 
+ * sub enhancement 2
+- Enhancement 2
+
+### Fixed
+- Bug fix 1
+ - sub bug 1
+ * sub bug 2
+- Bug fix 2
+
+### Security
+* Known issue 1
+- Known issue 2
+
+### Deprecated
+- Deprecated feature 1 
+* Future removal 2
+
+[Unreleased]: https://github.test_url/test_project
+[0.1.0]: https://github.test_url/test_project
+"""
+        )
 
 
 def test_first_patch_release(first_patch_changelog):
     assert keepachangelog.release(first_patch_changelog) == "0.0.1"
+    with open(first_patch_changelog) as file:
+        assert (
+            file.read()
+            == """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.1] - 2021-03-19
+### Fixed
+- Bug fix 1
+ - sub bug 1
+ * sub bug 2
+- Bug fix 2
+
+[Unreleased]: https://github.test_url/test_project
+[0.0.1]: https://github.test_url/test_project
+"""
+        )
 
 
 def test_empty_release(empty_changelog):


### PR DESCRIPTION
### Added
- `keepachangelog.release` function to guess new version number based on `Unreleased` section, update changelog and return new version number.
