### PR TITLE
Allow to get a raw content dict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `keepachangelog.release` function to guess new version number based on `Unreleased` section, update changelog and return new version number.
 - `keepachangelog.to_raw_dict` function returning a raw markdown description of the release under `raw` dict.
 
+### Fixed
+- Handle any category name.
+- Add more flexibility for release format.
+
+### Changed
+- `Unreleased` is now reported as lower cased `unreleased`.
+
 ## [0.4.0] - 2020-09-21
 ### Added
 - `keepachangelog.flask_restx.add_changelog_endpoint` function to add a changelog endpoint to a [Flask-RestX](https://flask-restx.readthedocs.io/en/latest/) application.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - `keepachangelog.release` function to guess new version number based on `Unreleased` section, update changelog and return new version number.
+- `keepachangelog.to_raw_dict` function returning a raw markdown description of the release under `raw` dict.
 
 ## [0.4.0] - 2020-09-21
 ### Added

--- a/keepachangelog/__init__.py
+++ b/keepachangelog/__init__.py
@@ -1,2 +1,2 @@
 from keepachangelog.version import __version__
-from keepachangelog._changelog import to_dict, release
+from keepachangelog._changelog import to_dict, to_raw_dict, release

--- a/keepachangelog/_changelog.py
+++ b/keepachangelog/_changelog.py
@@ -56,17 +56,32 @@ def add_information(category: List[str], line: str):
 def to_dict(changelog_path: str, *, show_unreleased: bool = False) -> Dict[str, dict]:
     changes = {}
     with open(changelog_path) as change_log:
-        release = {}
+        current_release = {}
         category = []
         for line in change_log:
             line = line.strip(" \n")
 
             if is_release(line, show_unreleased):
-                release = add_release(changes, line)
+                current_release = add_release(changes, line)
             elif is_category(line):
-                category = add_category(release, line)
+                category = add_category(current_release, line)
             elif is_information(line):
                 add_information(category, line)
+
+    return changes
+
+
+def to_raw_dict(changelog_path: str) -> Dict[str, dict]:
+    changes = {}
+    with open(changelog_path) as change_log:
+        current_release = {}
+        for line in change_log:
+            clean_line = line.strip(" \n")
+
+            if is_release(clean_line, show_unreleased=False):
+                current_release = add_release(changes, clean_line)
+            elif is_category(clean_line) or is_information(clean_line):
+                current_release["raw"] = current_release.get("raw", "") + line
 
     return changes
 

--- a/keepachangelog/_changelog.py
+++ b/keepachangelog/_changelog.py
@@ -28,9 +28,6 @@ def add_release(changes: Dict[str, dict], line: str, show_unreleased: bool) -> d
 
 
 def unlink(value: str) -> str:
-    if not value:
-        return value
-
     return value.lstrip("[").rstrip("]")
 
 

--- a/keepachangelog/_versioning.py
+++ b/keepachangelog/_versioning.py
@@ -37,13 +37,13 @@ def bump(unreleased: dict, version: str) -> str:
 def actual_version(changelog: dict) -> Optional[str]:
     versions = sorted(changelog.keys())
     current_version = versions.pop() if versions else None
-    while "Unreleased" == current_version:
+    while "unreleased" == current_version:
         current_version = versions.pop() if versions else None
     return current_version
 
 
 def guess_unreleased_version(changelog: dict) -> Tuple[Optional[str], str]:
-    unreleased = changelog.get("Unreleased", {})
+    unreleased = changelog.get("unreleased", {})
     if not unreleased or len(unreleased) < 3:
         raise Exception(
             "Release content must be provided within changelog Unreleased section."

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -119,3 +119,63 @@ def test_changelog_with_versions_and_all_categories(changelog):
             "version": "1.0.0",
         },
     }
+
+
+def test_raw_changelog_with_versions_and_all_categories(changelog):
+    assert keepachangelog.to_raw_dict(changelog) == {
+        "1.2.0": {
+            "raw": """### Changed
+- Release note 1.
+- Release note 2.
+### Added
+- Enhancement 1
+- sub enhancement 1
+- sub enhancement 2
+- Enhancement 2
+### Fixed
+- Bug fix 1
+- sub bug 1
+- sub bug 2
+- Bug fix 2
+### Security
+- Known issue 1
+- Known issue 2
+### Deprecated
+- Deprecated feature 1
+- Future removal 2
+### Removed
+- Deprecated feature 2
+- Future removal 1
+""",
+            "release_date": "2018-06-01",
+            "version": "1.2.0",
+        },
+        "1.1.0": {
+            "raw": """### Changed
+- Enhancement 1 (1.1.0)
+- sub enhancement 1
+- sub enhancement 2
+- Enhancement 2 (1.1.0)
+""",
+            "release_date": "2018-05-31",
+            "version": "1.1.0",
+        },
+        "1.0.1": {
+            "raw": """### Fixed
+- Bug fix 1 (1.0.1)
+- sub bug 1
+- sub bug 2
+- Bug fix 2 (1.0.1)
+""",
+            "release_date": "2018-05-31",
+            "version": "1.0.1",
+        },
+        "1.0.0": {
+            "raw": """### Deprecated
+- Known issue 1 (1.0.0)
+- Known issue 2 (1.0.0)
+""",
+            "release_date": "2017-04-10",
+            "version": "1.0.0",
+        },
+    }

--- a/tests/test_changelog_no_version.py
+++ b/tests/test_changelog_no_version.py
@@ -17,3 +17,7 @@ def changelog(tmpdir):
 
 def test_changelog_without_versions(changelog):
     assert keepachangelog.to_dict(changelog) == {}
+
+
+def test_raw_changelog_without_versions(changelog):
+    assert keepachangelog.to_raw_dict(changelog) == {}

--- a/tests/test_changelog_unreleased.py
+++ b/tests/test_changelog_unreleased.py
@@ -76,8 +76,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 def test_changelog_with_versions_and_all_categories(changelog):
     assert keepachangelog.to_dict(changelog, show_unreleased=True) == {
-        "Unreleased": {
-            "version": "Unreleased",
+        "unreleased": {
+            "version": "unreleased",
             "release_date": None,
             "changed": ["Release note 1.", "Release note 2."],
             "added": [

--- a/tests/test_non_standard_changelog.py
+++ b/tests/test_non_standard_changelog.py
@@ -1,0 +1,222 @@
+import os
+import os.path
+
+import pytest
+
+import keepachangelog
+
+
+@pytest.fixture
+def changelog(tmpdir):
+    changelog_file_path = os.path.join(tmpdir, "CHANGELOG.md")
+    with open(changelog_file_path, "wt") as file:
+        file.write(
+            """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## Master
+
+## 1.2.0 (August 28, 2019)
+### Changed
+- Release note 1.
+- Release note 2.
+
+### Added
+- Enhancement 1
+- sub enhancement 1
+- sub enhancement 2
+- Enhancement 2
+
+### Fixed
+- Bug fix 1
+- sub bug 1
+- sub bug 2
+- Bug fix 2
+
+### Security
+- Known issue 1
+- Known issue 2
+
+### Deprecated
+- Deprecated feature 1
+- Future removal 2
+
+### Removed
+- Deprecated feature 2
+- Future removal 1
+
+## [1.1.0] (May 03, 2018)
+### Changed
+- Enhancement 1 (1.1.0)
+- sub enhancement 1
+- sub enhancement 2
+- Enhancement 2 (1.1.0)
+
+## [1.0.1] - May 01, 2018
+### Fixed
+- Bug fix 1 (1.0.1)
+- sub bug 1
+- sub bug 2
+- Bug fix 2 (1.0.1)
+
+## 1.0.0 (2017-01-01)
+### Deprecated
+- Known issue 1 (1.0.0)
+- Known issue 2 (1.0.0)
+"""
+        )
+    return changelog_file_path
+
+
+def test_changelog_with_versions_and_all_categories(changelog):
+    assert keepachangelog.to_dict(changelog) == {
+        "1.2.0": {
+            "added": [
+                "Enhancement 1",
+                "sub enhancement 1",
+                "sub enhancement 2",
+                "Enhancement 2",
+            ],
+            "changed": ["Release note 1.", "Release note 2."],
+            "deprecated": ["Deprecated feature 1", "Future removal 2"],
+            "fixed": ["Bug fix 1", "sub bug 1", "sub bug 2", "Bug fix 2"],
+            "release_date": "august 28, 2019",
+            "removed": ["Deprecated feature 2", "Future removal 1"],
+            "security": ["Known issue 1", "Known issue 2"],
+            "version": "1.2.0",
+        },
+        "1.1.0": {
+            "changed": [
+                "Enhancement 1 (1.1.0)",
+                "sub enhancement 1",
+                "sub enhancement 2",
+                "Enhancement 2 (1.1.0)",
+            ],
+            "release_date": "may 03, 2018",
+            "version": "1.1.0",
+        },
+        "1.0.1": {
+            "fixed": [
+                "Bug fix 1 (1.0.1)",
+                "sub bug 1",
+                "sub bug 2",
+                "Bug fix 2 (1.0.1)",
+            ],
+            "release_date": "may 01, 2018",
+            "version": "1.0.1",
+        },
+        "1.0.0": {
+            "deprecated": ["Known issue 1 (1.0.0)", "Known issue 2 (1.0.0)"],
+            "release_date": "2017-01-01",
+            "version": "1.0.0",
+        },
+    }
+
+
+def test_changelog_with_unreleased_versions_and_all_categories(changelog):
+    assert keepachangelog.to_dict(changelog, show_unreleased=True) == {
+        "master": {"release_date": None, "version": "master"},
+        "1.2.0": {
+            "added": [
+                "Enhancement 1",
+                "sub enhancement 1",
+                "sub enhancement 2",
+                "Enhancement 2",
+            ],
+            "changed": ["Release note 1.", "Release note 2."],
+            "deprecated": ["Deprecated feature 1", "Future removal 2"],
+            "fixed": ["Bug fix 1", "sub bug 1", "sub bug 2", "Bug fix 2"],
+            "release_date": "august 28, 2019",
+            "removed": ["Deprecated feature 2", "Future removal 1"],
+            "security": ["Known issue 1", "Known issue 2"],
+            "version": "1.2.0",
+        },
+        "1.1.0": {
+            "changed": [
+                "Enhancement 1 (1.1.0)",
+                "sub enhancement 1",
+                "sub enhancement 2",
+                "Enhancement 2 (1.1.0)",
+            ],
+            "release_date": "may 03, 2018",
+            "version": "1.1.0",
+        },
+        "1.0.1": {
+            "fixed": [
+                "Bug fix 1 (1.0.1)",
+                "sub bug 1",
+                "sub bug 2",
+                "Bug fix 2 (1.0.1)",
+            ],
+            "release_date": "may 01, 2018",
+            "version": "1.0.1",
+        },
+        "1.0.0": {
+            "deprecated": ["Known issue 1 (1.0.0)", "Known issue 2 (1.0.0)"],
+            "release_date": "2017-01-01",
+            "version": "1.0.0",
+        },
+    }
+
+
+def test_raw_changelog_with_versions_and_all_categories(changelog):
+    assert keepachangelog.to_raw_dict(changelog) == {
+        "1.2.0": {
+            "raw": """### Changed
+- Release note 1.
+- Release note 2.
+### Added
+- Enhancement 1
+- sub enhancement 1
+- sub enhancement 2
+- Enhancement 2
+### Fixed
+- Bug fix 1
+- sub bug 1
+- sub bug 2
+- Bug fix 2
+### Security
+- Known issue 1
+- Known issue 2
+### Deprecated
+- Deprecated feature 1
+- Future removal 2
+### Removed
+- Deprecated feature 2
+- Future removal 1
+""",
+            "release_date": "august 28, 2019",
+            "version": "1.2.0",
+        },
+        "1.1.0": {
+            "raw": """### Changed
+- Enhancement 1 (1.1.0)
+- sub enhancement 1
+- sub enhancement 2
+- Enhancement 2 (1.1.0)
+""",
+            "release_date": "may 03, 2018",
+            "version": "1.1.0",
+        },
+        "1.0.1": {
+            "raw": """### Fixed
+- Bug fix 1 (1.0.1)
+- sub bug 1
+- sub bug 2
+- Bug fix 2 (1.0.1)
+""",
+            "release_date": "may 01, 2018",
+            "version": "1.0.1",
+        },
+        "1.0.0": {
+            "raw": """### Deprecated
+- Known issue 1 (1.0.0)
+- Known issue 2 (1.0.0)
+""",
+            "release_date": "2017-01-01",
+            "version": "1.0.0",
+        },
+    }


### PR DESCRIPTION
### Added
- `keepachangelog.to_raw_dict` function returning a raw markdown description of the release under `raw` dict.

### Fixed
- Handle any category name.
- Add more flexibility for release format.

### Changed
- `Unreleased` is now reported as lower cased `unreleased`.