### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - `keepachangelog.to_dict` now contains `url` key for each item if a link is available for the version.
+- `keepachangelog.to_raw_dict` now contains `url` key for each item if a link is available for the version.
 
 ## [0.5.0] - 2021-04-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `keepachangelog.to_dict` now contains `url` key for each item if a link is available for the version.
 - `keepachangelog.to_raw_dict` now contains `url` key for each item if a link is available for the version.
 
+### Fixed
+- `keepachangelog.release` now allows `pre-release` and `build metadata` information as part of valid semantic version. As per [semantic versioning specifications](https://semver.org). 
+  To ensure compatibility with some python specific versioning, `pre-release` is also handled as not being prefixed with `-`, or prefixed with `.`.
+- `keepachangelog.release` will now bump a pre-release version to a stable version. It was previously failing.
+
 ## [0.5.0] - 2021-04-19
 ### Added
 - `keepachangelog.release` function to guess new version number based on `Unreleased` section, update changelog and return new version number.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - `keepachangelog.to_dict` now contains `url` key for each item if a link is available for the version.
 - `keepachangelog.to_raw_dict` now contains `url` key for each item if a link is available for the version.
+- `keepachangelog.to_dict` now contains `semantic_version` key for each item if the version follows semantic versioning.
+- `keepachangelog.to_raw_dict` now contains `semantic_version` key for each item if the version follows semantic versioning.
 
 ### Fixed
 - `keepachangelog.release` now allows `pre-release` and `build metadata` information as part of valid semantic version. As per [semantic versioning specifications](https://semver.org). 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.0] - 2021-05-21
 ### Changed
 - `keepachangelog.to_dict` now contains `url` key for each item if a link is available for the version.
 - `keepachangelog.to_raw_dict` now contains `url` key for each item if a link is available for the version.
@@ -55,7 +57,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/Colin-b/keepachangelog/compare/v0.5.0...HEAD
+[Unreleased]: https://github.com/Colin-b/keepachangelog/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/Colin-b/keepachangelog/compare/v0.5.0...v1.0.0
 [0.5.0]: https://github.com/Colin-b/keepachangelog/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/Colin-b/keepachangelog/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/Colin-b/keepachangelog/compare/v0.3.0...v0.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- `keepachangelog.to_dict` now contains `url` key for each item if a link is available for the version.
 
 ## [0.5.0] - 2021-04-19
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `keepachangelog.to_dict` now contains `semantic_version` key for each item if the version follows semantic versioning.
 - `keepachangelog.to_raw_dict` now contains `semantic_version` key for each item if the version follows semantic versioning.
 
+### Added
+- `keepachangelog.release` is now allowing to provide a custom new version thanks to the new `new_version` parameter.
+
 ### Fixed
 - `keepachangelog.release` now allows `pre-release` and `build metadata` information as part of valid semantic version. As per [semantic versioning specifications](https://semver.org). 
   To ensure compatibility with some python specific versioning, `pre-release` is also handled as not being prefixed with `-`, or prefixed with `.`.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ changes = {
         ],
         "release_date": "2018-05-31",
         "version": "1.1.0",
+        "semantic_version": {
+            "major": 1,
+            "minor": 1,
+            "patch": 0,
+            "prerelease": None,
+            "buildmetadata": None,
+        },
         "url": "https://github.test_url/test_project/compare/v1.0.1...v1.1.0",
     },
     "1.0.1": {
@@ -49,12 +56,26 @@ changes = {
         ],
         "release_date": "2018-05-31",
         "version": "1.0.1",
+        "semantic_version": {
+            "major": 1,
+            "minor": 0,
+            "patch": 1,
+            "prerelease": None,
+            "buildmetadata": None,
+        },
         "url": "https://github.test_url/test_project/compare/v1.0.0...v1.0.1",
     },
     "1.0.0": {
         "deprecated": ["Known issue 1 (1.0.0)", "Known issue 2 (1.0.0)"],
         "release_date": "2017-04-10",
         "version": "1.0.0",
+        "semantic_version": {
+            "major": 1,
+            "minor": 0,
+            "patch": 0,
+            "prerelease": None,
+            "buildmetadata": None,
+        },
         "url": "https://github.test_url/test_project/releases/tag/v1.0.0",
     },
 }

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ changes = {
         ],
         "release_date": "2018-05-31",
         "version": "1.1.0",
+        "url": "https://github.test_url/test_project/compare/v1.0.1...v1.1.0",
     },
     "1.0.1": {
         "fixed": [
@@ -48,11 +49,13 @@ changes = {
         ],
         "release_date": "2018-05-31",
         "version": "1.0.1",
+        "url": "https://github.test_url/test_project/compare/v1.0.0...v1.0.1",
     },
     "1.0.0": {
         "deprecated": ["Known issue 1 (1.0.0)", "Known issue 2 (1.0.0)"],
         "release_date": "2017-04-10",
         "version": "1.0.0",
+        "url": "https://github.test_url/test_project/releases/tag/v1.0.0",
     },
 }
 ```

--- a/README.md
+++ b/README.md
@@ -147,6 +147,72 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 `show_unreleased` parameter can be specified in order to include `Unreleased` section information.
 Note that `release_date` will be set to None in such as case.
 
+### Retrieving the raw content
+
+If for some reason you would like to retrieve the raw content of a release you can use `to_raw_dict` instead.
+
+```python
+import keepachangelog
+
+changes = keepachangelog.to_raw_dict("path/to/CHANGELOG.md")
+```
+
+`changes` would look like:
+
+```python
+changes = {
+    "1.1.0": {
+        "raw": """### Changed
+- Enhancement 1 (1.1.0)
+ - sub enhancement 1
+ - sub enhancement 2
+- Enhancement 2 (1.1.0)""",
+        "release_date": "2018-05-31",
+        "version": "1.1.0",
+        "semantic_version": {
+            "major": 1,
+            "minor": 1,
+            "patch": 0,
+            "prerelease": None,
+            "buildmetadata": None,
+        },
+        "url": "https://github.test_url/test_project/compare/v1.0.1...v1.1.0",
+    },
+    "1.0.1": {
+        "raw": """### Fixed
+- Bug fix 1 (1.0.1)
+ - sub bug 1
+ - sub bug 2
+- Bug fix 2 (1.0.1)""",
+        "release_date": "2018-05-31",
+        "version": "1.0.1",
+        "semantic_version": {
+            "major": 1,
+            "minor": 0,
+            "patch": 1,
+            "prerelease": None,
+            "buildmetadata": None,
+        },
+        "url": "https://github.test_url/test_project/compare/v1.0.0...v1.0.1",
+    },
+    "1.0.0": {
+        "raw": """### Deprecated
+- Known issue 1 (1.0.0)
+- Known issue 2 (1.0.0)""",
+        "release_date": "2017-04-10",
+        "version": "1.0.0",
+        "semantic_version": {
+            "major": 1,
+            "minor": 0,
+            "patch": 0,
+            "prerelease": None,
+            "buildmetadata": None,
+        },
+        "url": "https://github.test_url/test_project/releases/tag/v1.0.0",
+    },
+}
+```
+
 ## Release
 
 You can create a new release by using `keepachangelog.release` function.
@@ -158,7 +224,7 @@ new_version = keepachangelog.release("path/to/CHANGELOG.md")
 ```
 
 This will:
-* Guess the new version number and return it:
+* If `new_version` parameter is not provided, guess the new version number and return it:
   * `Removed` or `Changed` sections will be considered as breaking changes, thus incrementing the major version.
   * If the only section is `Fixed`, only patch will be incremented.
   * Otherwise, minor will be incremented.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://travis-ci.com/Colin-b/keepachangelog"><img alt="Build status" src="https://api.travis-ci.com/Colin-b/keepachangelog.svg?branch=master"></a>
 <a href="https://travis-ci.com/Colin-b/keepachangelog"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://travis-ci.com/Colin-b/keepachangelog"><img alt="Number of tests" src="https://img.shields.io/badge/tests-29 passed-blue"></a>
+<a href="https://travis-ci.com/Colin-b/keepachangelog"><img alt="Number of tests" src="https://img.shields.io/badge/tests-30 passed-blue"></a>
 <a href="https://pypi.org/project/keepachangelog/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/keepachangelog"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://travis-ci.com/Colin-b/keepachangelog"><img alt="Build status" src="https://api.travis-ci.com/Colin-b/keepachangelog.svg?branch=master"></a>
 <a href="https://travis-ci.com/Colin-b/keepachangelog"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://travis-ci.com/Colin-b/keepachangelog"><img alt="Number of tests" src="https://img.shields.io/badge/tests-30 passed-blue"></a>
+<a href="https://travis-ci.com/Colin-b/keepachangelog"><img alt="Number of tests" src="https://img.shields.io/badge/tests-31 passed-blue"></a>
 <a href="https://pypi.org/project/keepachangelog/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/keepachangelog"></a>
 </p>
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <a href="https://travis-ci.com/Colin-b/keepachangelog"><img alt="Build status" src="https://api.travis-ci.com/Colin-b/keepachangelog.svg?branch=master"></a>
 <a href="https://travis-ci.com/Colin-b/keepachangelog"><img alt="Coverage" src="https://img.shields.io/badge/coverage-100%25-brightgreen"></a>
 <a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
-<a href="https://travis-ci.com/Colin-b/keepachangelog"><img alt="Number of tests" src="https://img.shields.io/badge/tests-28 passed-blue"></a>
+<a href="https://travis-ci.com/Colin-b/keepachangelog"><img alt="Number of tests" src="https://img.shields.io/badge/tests-29 passed-blue"></a>
 <a href="https://pypi.org/project/keepachangelog/"><img alt="Number of downloads" src="https://img.shields.io/pypi/dm/keepachangelog"></a>
 </p>
 

--- a/keepachangelog/_changelog.py
+++ b/keepachangelog/_changelog.py
@@ -3,6 +3,7 @@ import re
 from typing import Dict, List, Optional
 
 from keepachangelog._versioning import (
+    actual_version,
     guess_unreleased_version,
     to_semantic,
     InvalidSemanticVersion,
@@ -120,7 +121,8 @@ def to_raw_dict(changelog_path: str) -> Dict[str, dict]:
 
 def release(changelog_path: str) -> str:
     changelog = to_dict(changelog_path, show_unreleased=True)
-    current_version, new_version = guess_unreleased_version(changelog)
+    current_version, current_semantic_version = actual_version(changelog)
+    new_version = guess_unreleased_version(changelog, current_semantic_version)
     release_version(changelog_path, current_version, new_version)
     return new_version
 

--- a/keepachangelog/_changelog.py
+++ b/keepachangelog/_changelog.py
@@ -119,10 +119,11 @@ def to_raw_dict(changelog_path: str) -> Dict[str, dict]:
     return changes
 
 
-def release(changelog_path: str) -> str:
+def release(changelog_path: str, new_version: str = None) -> str:
     changelog = to_dict(changelog_path, show_unreleased=True)
     current_version, current_semantic_version = actual_version(changelog)
-    new_version = guess_unreleased_version(changelog, current_semantic_version)
+    if not new_version:
+        new_version = guess_unreleased_version(changelog, current_semantic_version)
     release_version(changelog_path, current_version, new_version)
     return new_version
 

--- a/keepachangelog/_changelog.py
+++ b/keepachangelog/_changelog.py
@@ -2,7 +2,11 @@ import datetime
 import re
 from typing import Dict, List, Optional
 
-from keepachangelog._versioning import guess_unreleased_version
+from keepachangelog._versioning import (
+    guess_unreleased_version,
+    to_semantic,
+    InvalidSemanticVersion,
+)
 
 
 def is_release(line: str) -> bool:
@@ -21,10 +25,14 @@ def add_release(changes: Dict[str, dict], line: str, show_unreleased: bool) -> d
     if not show_unreleased and not release_date:
         return {}
     version = unlink(version)
-    return changes.setdefault(
-        version,
-        {"version": version, "release_date": extract_date(release_date)},
-    )
+
+    release_details = {"version": version, "release_date": extract_date(release_date)}
+    try:
+        release_details["semantic_version"] = to_semantic(version)
+    except InvalidSemanticVersion:
+        pass
+
+    return changes.setdefault(version, release_details)
 
 
 def unlink(value: str) -> str:

--- a/keepachangelog/_versioning.py
+++ b/keepachangelog/_versioning.py
@@ -7,8 +7,7 @@ def contains_breaking_changes(unreleased: dict) -> bool:
 
 
 def only_contains_bug_fixes(unreleased: dict) -> bool:
-    # unreleased contains at least 2 entries: version and release_date
-    return "fixed" in unreleased and len(unreleased) == 3
+    return ["fixed"] == list(unreleased)
 
 
 def bump_major(version: str) -> str:
@@ -44,7 +43,12 @@ def actual_version(changelog: dict) -> Optional[str]:
 
 def guess_unreleased_version(changelog: dict) -> Tuple[Optional[str], str]:
     unreleased = changelog.get("unreleased", {})
-    if not unreleased or len(unreleased) < 3:
+    # Only keep user provided entries
+    unreleased = unreleased.copy()
+    unreleased.pop("version", None)
+    unreleased.pop("release_date", None)
+    unreleased.pop("url", None)
+    if not unreleased:
         raise Exception(
             "Release content must be provided within changelog Unreleased section."
         )

--- a/keepachangelog/_versioning.py
+++ b/keepachangelog/_versioning.py
@@ -2,6 +2,15 @@ import re
 from typing import Tuple, Optional
 
 
+initial_semantic_version = {
+    "major": 0,
+    "minor": 0,
+    "patch": 0,
+    "prerelease": None,
+    "buildmetadata": None,
+}
+
+
 def contains_breaking_changes(unreleased: dict) -> bool:
     return "removed" in unreleased or "changed" in unreleased
 
@@ -10,35 +19,59 @@ def only_contains_bug_fixes(unreleased: dict) -> bool:
     return ["fixed"] == list(unreleased)
 
 
-def bump_major(version: str) -> str:
-    major, *_ = to_semantic(version)
-    return from_semantic(major + 1, 0, 0)
+def bump_major(semantic_version: dict):
+    semantic_version["major"] += 1
+    semantic_version["minor"] = 0
+    semantic_version["patch"] = 0
+    semantic_version["prerelease"] = None
+    semantic_version["buildmetadata"] = None
 
 
-def bump_minor(version: str) -> str:
-    major, minor, _ = to_semantic(version)
-    return from_semantic(major, minor + 1, 0)
+def bump_minor(semantic_version: dict) -> str:
+    semantic_version["minor"] += 1
+    semantic_version["patch"] = 0
+    semantic_version["prerelease"] = None
+    semantic_version["buildmetadata"] = None
 
 
-def bump_patch(version: str) -> str:
-    major, minor, patch = to_semantic(version)
-    return from_semantic(major, minor, patch + 1)
+def bump_patch(semantic_version: dict) -> str:
+    semantic_version["patch"] += 1
+    semantic_version["prerelease"] = None
+    semantic_version["buildmetadata"] = None
 
 
-def bump(unreleased: dict, version: str) -> str:
-    if contains_breaking_changes(unreleased):
-        return bump_major(version)
-    if only_contains_bug_fixes(unreleased):
-        return bump_patch(version)
-    return bump_minor(version)
+def bump(unreleased: dict, semantic_version: dict) -> dict:
+    if semantic_version["prerelease"]:
+        semantic_version["prerelease"] = None
+        semantic_version["buildmetadata"] = None
+    elif contains_breaking_changes(unreleased):
+        bump_major(semantic_version)
+    elif only_contains_bug_fixes(unreleased):
+        bump_patch(semantic_version)
+    else:
+        bump_minor(semantic_version)
+    return semantic_version
 
 
-def actual_version(changelog: dict) -> Optional[str]:
-    versions = sorted(changelog.keys())
-    current_version = versions.pop() if versions else None
-    while "unreleased" == current_version:
-        current_version = versions.pop() if versions else None
-    return current_version
+def semantic_order(version: Tuple[str, dict]) -> str:
+    _, semantic_version = version
+    # Ensure release is "bigger than" pre-release
+    pre_release_order = (
+        f"0{semantic_version['prerelease']}" if semantic_version["prerelease"] else "1"
+    )
+    return f"{semantic_version['major']}.{semantic_version['minor']}.{semantic_version['patch']}.{pre_release_order}"
+
+
+def actual_version(changelog: dict) -> Tuple[Optional[str], dict]:
+    versions = sorted(
+        [
+            (version, to_semantic(version))
+            for version in changelog.keys()
+            if version != "unreleased"
+        ],
+        key=semantic_order,
+    )
+    return versions.pop() if versions else (None, initial_semantic_version.copy())
 
 
 def guess_unreleased_version(changelog: dict) -> Tuple[Optional[str], str]:
@@ -53,24 +86,30 @@ def guess_unreleased_version(changelog: dict) -> Tuple[Optional[str], str]:
             "Release content must be provided within changelog Unreleased section."
         )
 
-    version = actual_version(changelog)
-    return version, bump(unreleased, version)
+    version, semantic_version = actual_version(changelog)
+    return version, from_semantic(bump(unreleased, semantic_version))
 
 
-# Semantic versioning pattern should match version like 1.2.3"
-version_pattern = re.compile(r"^(\d+)\.(\d+)\.(\d+)$")
+semantic_versioning = re.compile(
+    r"^(?P<major>0|[1-9]\d*)\.(?P<minor>0|[1-9]\d*)\.(?P<patch>0|[1-9]\d*)(?:[-\.]?(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
+)
 
 
-def to_semantic(version: Optional[str]) -> Tuple[int, int, int]:
+def to_semantic(version: Optional[str]) -> dict:
     if not version:
-        return 0, 0, 0
+        return initial_semantic_version.copy()
 
-    match = version_pattern.fullmatch(version)
+    match = semantic_versioning.fullmatch(version)
     if match:
-        return int(match.group(1)), int(match.group(2)), int(match.group(3))
+        return {
+            key: int(value) if key in ("major", "minor", "patch") else value
+            for key, value in match.groupdict().items()
+        }
 
-    raise Exception(f"{version} is not following semantic versioning.")
+    raise Exception(
+        f"{version} is not following semantic versioning. Check https://semver.org for more information."
+    )
 
 
-def from_semantic(major: int, minor: int, patch: int) -> str:
-    return f"{major}.{minor}.{patch}"
+def from_semantic(semantic_version: dict) -> str:
+    return f"{semantic_version['major']}.{semantic_version['minor']}.{semantic_version['patch']}"

--- a/keepachangelog/_versioning.py
+++ b/keepachangelog/_versioning.py
@@ -81,7 +81,7 @@ def actual_version(changelog: dict) -> Tuple[Optional[str], dict]:
     return versions.pop() if versions else (None, initial_semantic_version.copy())
 
 
-def guess_unreleased_version(changelog: dict) -> Tuple[Optional[str], str]:
+def guess_unreleased_version(changelog: dict, current_semantic_version: dict) -> str:
     unreleased = changelog.get("unreleased", {})
     # Only keep user provided entries
     unreleased = unreleased.copy()
@@ -93,8 +93,7 @@ def guess_unreleased_version(changelog: dict) -> Tuple[Optional[str], str]:
             "Release content must be provided within changelog Unreleased section."
         )
 
-    version, semantic_version = actual_version(changelog)
-    return version, from_semantic(bump(unreleased, semantic_version))
+    return from_semantic(bump(unreleased, current_semantic_version))
 
 
 semantic_versioning = re.compile(

--- a/keepachangelog/_versioning.py
+++ b/keepachangelog/_versioning.py
@@ -11,6 +11,13 @@ initial_semantic_version = {
 }
 
 
+class InvalidSemanticVersion(Exception):
+    def __init__(self, version: str):
+        super().__init__(
+            f"{version} is not following semantic versioning. Check https://semver.org for more information."
+        )
+
+
 def contains_breaking_changes(unreleased: dict) -> bool:
     return "removed" in unreleased or "changed" in unreleased
 
@@ -106,9 +113,7 @@ def to_semantic(version: Optional[str]) -> dict:
             for key, value in match.groupdict().items()
         }
 
-    raise Exception(
-        f"{version} is not following semantic versioning. Check https://semver.org for more information."
-    )
+    raise InvalidSemanticVersion(version)
 
 
 def from_semantic(semantic_version: dict) -> str:

--- a/keepachangelog/version.py
+++ b/keepachangelog/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "0.5.0"
+__version__ = "1.0.0"

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
             "requests",
             "starlette==0.13.*",
             # Used to check flask-restx endpoint
+            "flask==1.*",
             "flask-restx==0.2.*",
             # Used to check coverage
             "pytest-cov==2.*",

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -92,6 +92,13 @@ def test_changelog_with_versions_and_all_categories(changelog):
             "removed": ["Deprecated feature 2", "Future removal 1"],
             "security": ["Known issue 1", "Known issue 2"],
             "version": "1.2.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 2,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
         "1.1.0": {
             "changed": [
@@ -102,6 +109,13 @@ def test_changelog_with_versions_and_all_categories(changelog):
             ],
             "release_date": "2018-05-31",
             "version": "1.1.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 1,
+                "patch": 0,
+                "prerelease": None,
+            },
             "url": "https://github.test_url/test_project/compare/v1.0.1...v1.1.0",
         },
         "1.0.1": {
@@ -113,12 +127,26 @@ def test_changelog_with_versions_and_all_categories(changelog):
             ],
             "release_date": "2018-05-31",
             "version": "1.0.1",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 1,
+                "prerelease": None,
+            },
             "url": "https://github.test_url/test_project/compare/v1.0.0...v1.0.1",
         },
         "1.0.0": {
             "deprecated": ["Known issue 1 (1.0.0)", "Known issue 2 (1.0.0)"],
             "release_date": "2017-04-10",
             "version": "1.0.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 0,
+                "prerelease": None,
+            },
             "url": "https://github.test_url/test_project/releases/tag/v1.0.0",
         },
     }
@@ -152,6 +180,13 @@ def test_raw_changelog_with_versions_and_all_categories(changelog):
 """,
             "release_date": "2018-06-01",
             "version": "1.2.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 2,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
         "1.1.0": {
             "raw": """### Changed
@@ -162,6 +197,13 @@ def test_raw_changelog_with_versions_and_all_categories(changelog):
 """,
             "release_date": "2018-05-31",
             "version": "1.1.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 1,
+                "patch": 0,
+                "prerelease": None,
+            },
             "url": "https://github.test_url/test_project/compare/v1.0.1...v1.1.0",
         },
         "1.0.1": {
@@ -173,6 +215,13 @@ def test_raw_changelog_with_versions_and_all_categories(changelog):
 """,
             "release_date": "2018-05-31",
             "version": "1.0.1",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 1,
+                "prerelease": None,
+            },
             "url": "https://github.test_url/test_project/compare/v1.0.0...v1.0.1",
         },
         "1.0.0": {
@@ -182,6 +231,13 @@ def test_raw_changelog_with_versions_and_all_categories(changelog):
 """,
             "release_date": "2017-04-10",
             "version": "1.0.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 0,
+                "prerelease": None,
+            },
             "url": "https://github.test_url/test_project/releases/tag/v1.0.0",
         },
     }

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -162,6 +162,7 @@ def test_raw_changelog_with_versions_and_all_categories(changelog):
 """,
             "release_date": "2018-05-31",
             "version": "1.1.0",
+            "url": "https://github.test_url/test_project/compare/v1.0.1...v1.1.0",
         },
         "1.0.1": {
             "raw": """### Fixed
@@ -172,6 +173,7 @@ def test_raw_changelog_with_versions_and_all_categories(changelog):
 """,
             "release_date": "2018-05-31",
             "version": "1.0.1",
+            "url": "https://github.test_url/test_project/compare/v1.0.0...v1.0.1",
         },
         "1.0.0": {
             "raw": """### Deprecated
@@ -180,5 +182,6 @@ def test_raw_changelog_with_versions_and_all_categories(changelog):
 """,
             "release_date": "2017-04-10",
             "version": "1.0.0",
+            "url": "https://github.test_url/test_project/releases/tag/v1.0.0",
         },
     }

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -102,6 +102,7 @@ def test_changelog_with_versions_and_all_categories(changelog):
             ],
             "release_date": "2018-05-31",
             "version": "1.1.0",
+            "url": "https://github.test_url/test_project/compare/v1.0.1...v1.1.0",
         },
         "1.0.1": {
             "fixed": [
@@ -112,11 +113,13 @@ def test_changelog_with_versions_and_all_categories(changelog):
             ],
             "release_date": "2018-05-31",
             "version": "1.0.1",
+            "url": "https://github.test_url/test_project/compare/v1.0.0...v1.0.1",
         },
         "1.0.0": {
             "deprecated": ["Known issue 1 (1.0.0)", "Known issue 2 (1.0.0)"],
             "release_date": "2017-04-10",
             "version": "1.0.0",
+            "url": "https://github.test_url/test_project/releases/tag/v1.0.0",
         },
     }
 

--- a/tests/test_changelog_empty_version.py
+++ b/tests/test_changelog_empty_version.py
@@ -1,0 +1,67 @@
+import os
+import os.path
+
+import pytest
+
+import keepachangelog
+
+
+@pytest.fixture
+def changelog(tmpdir):
+    changelog_file_path = os.path.join(tmpdir, "CHANGELOG.md")
+    with open(changelog_file_path, "wt") as file:
+        file.write(
+            """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [] - 2018-06-01
+### Changed
+- Release note 1.
+- Release note 2.
+
+### Fixed
+- Bug fix 1
+- sub bug 1
+- sub bug 2
+- Bug fix 2
+
+### Security
+- Known issue 1
+- Known issue 2
+
+### Deprecated
+- Deprecated feature 1
+- Future removal 2
+
+### Removed
+- Deprecated feature 2
+- Future removal 1
+"""
+        )
+    return changelog_file_path
+
+
+def test_changelog_with_empty_version(changelog):
+    assert keepachangelog.to_dict(changelog) == {
+        "": {
+            "changed": ["Release note 1.", "Release note 2."],
+            "deprecated": ["Deprecated feature 1", "Future removal 2"],
+            "fixed": ["Bug fix 1", "sub bug 1", "sub bug 2", "Bug fix 2"],
+            "release_date": "2018-06-01",
+            "removed": ["Deprecated feature 2", "Future removal 1"],
+            "security": ["Known issue 1", "Known issue 2"],
+            "version": "",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 0,
+                "minor": 0,
+                "patch": 0,
+                "prerelease": None,
+            },
+        },
+    }

--- a/tests/test_changelog_no_added.py
+++ b/tests/test_changelog_no_added.py
@@ -75,6 +75,13 @@ def test_changelog_with_versions_and_no_added(changelog):
             "removed": ["Deprecated feature 2", "Future removal 1"],
             "security": ["Known issue 1", "Known issue 2"],
             "version": "1.2.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 2,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
         "1.1.0": {
             "changed": [
@@ -85,6 +92,13 @@ def test_changelog_with_versions_and_no_added(changelog):
             ],
             "release_date": "2018-05-31",
             "version": "1.1.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 1,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
         "1.0.1": {
             "fixed": [
@@ -95,10 +109,24 @@ def test_changelog_with_versions_and_no_added(changelog):
             ],
             "release_date": "2018-05-31",
             "version": "1.0.1",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 1,
+                "prerelease": None,
+            },
         },
         "1.0.0": {
             "deprecated": ["Known issue 1 (1.0.0)", "Known issue 2 (1.0.0)"],
             "release_date": "2017-04-10",
             "version": "1.0.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
     }

--- a/tests/test_changelog_no_changed.py
+++ b/tests/test_changelog_no_changed.py
@@ -77,8 +77,25 @@ def test_changelog_with_versions_and_no_changed(changelog):
             "removed": ["Deprecated feature 2", "Future removal 1"],
             "security": ["Known issue 1", "Known issue 2"],
             "version": "1.2.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 2,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
-        "1.1.0": {"release_date": "2018-05-31", "version": "1.1.0"},
+        "1.1.0": {
+            "release_date": "2018-05-31",
+            "version": "1.1.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 1,
+                "patch": 0,
+                "prerelease": None,
+            },
+        },
         "1.0.1": {
             "fixed": [
                 "Bug fix 1 (1.0.1)",
@@ -88,10 +105,24 @@ def test_changelog_with_versions_and_no_changed(changelog):
             ],
             "release_date": "2018-05-31",
             "version": "1.0.1",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 1,
+                "prerelease": None,
+            },
         },
         "1.0.0": {
             "deprecated": ["Known issue 1 (1.0.0)", "Known issue 2 (1.0.0)"],
             "release_date": "2017-04-10",
             "version": "1.0.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
     }

--- a/tests/test_changelog_no_deprecated.py
+++ b/tests/test_changelog_no_deprecated.py
@@ -79,6 +79,13 @@ def test_changelog_with_versions_and_no_deprecated(changelog):
             "removed": ["Deprecated feature 2", "Future removal 1"],
             "security": ["Known issue 1", "Known issue 2"],
             "version": "1.2.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 2,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
         "1.1.0": {
             "changed": [
@@ -89,6 +96,13 @@ def test_changelog_with_versions_and_no_deprecated(changelog):
             ],
             "release_date": "2018-05-31",
             "version": "1.1.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 1,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
         "1.0.1": {
             "fixed": [
@@ -99,6 +113,23 @@ def test_changelog_with_versions_and_no_deprecated(changelog):
             ],
             "release_date": "2018-05-31",
             "version": "1.0.1",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 1,
+                "prerelease": None,
+            },
         },
-        "1.0.0": {"release_date": "2017-04-10", "version": "1.0.0"},
+        "1.0.0": {
+            "release_date": "2017-04-10",
+            "version": "1.0.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 0,
+                "prerelease": None,
+            },
+        },
     }

--- a/tests/test_changelog_no_fixed.py
+++ b/tests/test_changelog_no_fixed.py
@@ -80,6 +80,13 @@ def test_changelog_with_versions_and_no_fixed(changelog):
             "removed": ["Deprecated feature 2", "Future removal 1"],
             "security": ["Known issue 1", "Known issue 2"],
             "version": "1.2.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 2,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
         "1.1.0": {
             "changed": [
@@ -90,6 +97,13 @@ def test_changelog_with_versions_and_no_fixed(changelog):
             ],
             "release_date": "2018-05-31",
             "version": "1.1.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 1,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
         "1.0.1": {
             "fixed": [
@@ -100,10 +114,24 @@ def test_changelog_with_versions_and_no_fixed(changelog):
             ],
             "release_date": "2018-05-31",
             "version": "1.0.1",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 1,
+                "prerelease": None,
+            },
         },
         "1.0.0": {
             "deprecated": ["Known issue 1 (1.0.0)", "Known issue 2 (1.0.0)"],
             "release_date": "2017-04-10",
             "version": "1.0.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
     }

--- a/tests/test_changelog_no_removed.py
+++ b/tests/test_changelog_no_removed.py
@@ -82,6 +82,13 @@ def test_changelog_with_versions_and_no_removed(changelog):
             "release_date": "2018-06-01",
             "security": ["Known issue 1", "Known issue 2"],
             "version": "1.2.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 2,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
         "1.1.0": {
             "changed": [
@@ -92,6 +99,13 @@ def test_changelog_with_versions_and_no_removed(changelog):
             ],
             "release_date": "2018-05-31",
             "version": "1.1.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 1,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
         "1.0.1": {
             "fixed": [
@@ -102,10 +116,24 @@ def test_changelog_with_versions_and_no_removed(changelog):
             ],
             "release_date": "2018-05-31",
             "version": "1.0.1",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 1,
+                "prerelease": None,
+            },
         },
         "1.0.0": {
             "deprecated": ["Known issue 1 (1.0.0)", "Known issue 2 (1.0.0)"],
             "release_date": "2017-04-10",
             "version": "1.0.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
     }

--- a/tests/test_changelog_no_security.py
+++ b/tests/test_changelog_no_security.py
@@ -82,6 +82,13 @@ def test_changelog_with_versions_and_no_security(changelog):
             "release_date": "2018-06-01",
             "removed": ["Deprecated feature 2", "Future removal 1"],
             "version": "1.2.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 2,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
         "1.1.0": {
             "changed": [
@@ -92,6 +99,13 @@ def test_changelog_with_versions_and_no_security(changelog):
             ],
             "release_date": "2018-05-31",
             "version": "1.1.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 1,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
         "1.0.1": {
             "fixed": [
@@ -102,10 +116,24 @@ def test_changelog_with_versions_and_no_security(changelog):
             ],
             "release_date": "2018-05-31",
             "version": "1.0.1",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 1,
+                "prerelease": None,
+            },
         },
         "1.0.0": {
             "deprecated": ["Known issue 1 (1.0.0)", "Known issue 2 (1.0.0)"],
             "release_date": "2017-04-10",
             "version": "1.0.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
     }

--- a/tests/test_changelog_release.py
+++ b/tests/test_changelog_release.py
@@ -777,3 +777,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhancement 2 (1.1.0)
 """
         )
+
+
+def test_custom_release(unstable_changelog, mock_date):
+    assert (
+        keepachangelog.release(unstable_changelog, new_version="2.5.0b52") == "2.5.0b52"
+    )
+    with open(unstable_changelog) as file:
+        assert (
+            file.read()
+            == """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.5.0b52] - 2021-03-19
+### Changed
+- Enhancement 1 (1.1.0)
+
+## [2.5.0b51] - 2018-05-31
+### Changed
+- Enhancement 1 (1.1.0)
+- sub *enhancement 1*
+- sub enhancement 2
+- Enhancement 2 (1.1.0)
+"""
+        )

--- a/tests/test_changelog_release.py
+++ b/tests/test_changelog_release.py
@@ -79,6 +79,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - sub enhancement 2
 - Enhancement 2 (1.1.0)
 
+## [1.1.0.dev0] - 2018-05-31
+### Changed
+- Enhancement 1 (1.1.0)
+- sub *enhancement 1*
+- sub enhancement 2
+- Enhancement 2 (1.1.0)
+
 ## [1.0.1] - 2018-05-31
 ### Fixed
 - Bug fix 1 (1.0.1)
@@ -140,6 +147,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhancement 2 (1.1.0)
 
 ## [1.0.1] - 2018-05-31
+### Fixed
+- Bug fix 1 (1.0.1)
+- sub bug 1
+- sub bug 2
+- Bug fix 2 (1.0.1)
+
+## [1.0.1.dev0] - 2018-05-31
 ### Fixed
 - Bug fix 1 (1.0.1)
 - sub bug 1
@@ -377,6 +391,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     return changelog_file_path
 
 
+@pytest.fixture
+def unstable_changelog(tmpdir):
+    changelog_file_path = os.path.join(tmpdir, "UNSTABLE_CHANGELOG.md")
+    with open(changelog_file_path, "wt") as file:
+        file.write(
+            """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Changed
+- Enhancement 1 (1.1.0)
+
+## [2.5.0b51] - 2018-05-31
+### Changed
+- Enhancement 1 (1.1.0)
+- sub *enhancement 1*
+- sub enhancement 2
+- Enhancement 2 (1.1.0)
+"""
+        )
+    return changelog_file_path
+
+
 def test_major_release(major_changelog, mock_date):
     assert keepachangelog.release(major_changelog) == "2.0.0"
     with open(major_changelog) as file:
@@ -420,6 +460,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Future removal 1 
 
 ## [1.1.0] - 2018-05-31
+### Changed
+- Enhancement 1 (1.1.0)
+- sub *enhancement 1*
+- sub enhancement 2
+- Enhancement 2 (1.1.0)
+
+## [1.1.0.dev0] - 2018-05-31
 ### Changed
 - Enhancement 1 (1.1.0)
 - sub *enhancement 1*
@@ -489,6 +536,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enhancement 2 (1.1.0)
 
 ## [1.0.1] - 2018-05-31
+### Fixed
+- Bug fix 1 (1.0.1)
+- sub bug 1
+- sub bug 2
+- Bug fix 2 (1.0.1)
+
+## [1.0.1.dev0] - 2018-05-31
 ### Fixed
 - Bug fix 1 (1.0.1)
 - sub bug 1
@@ -692,4 +746,34 @@ def test_empty_unreleased_release(empty_unreleased_changelog):
 def test_non_semantic_release(non_semantic_changelog):
     with pytest.raises(Exception) as exception_info:
         keepachangelog.release(non_semantic_changelog)
-    assert str(exception_info.value) == "20180531 is not following semantic versioning."
+    assert (
+        str(exception_info.value)
+        == "20180531 is not following semantic versioning. Check https://semver.org for more information."
+    )
+
+
+def test_first_stable_release(unstable_changelog, mock_date):
+    assert keepachangelog.release(unstable_changelog) == "2.5.0"
+    with open(unstable_changelog) as file:
+        assert (
+            file.read()
+            == """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [2.5.0] - 2021-03-19
+### Changed
+- Enhancement 1 (1.1.0)
+
+## [2.5.0b51] - 2018-05-31
+### Changed
+- Enhancement 1 (1.1.0)
+- sub *enhancement 1*
+- sub enhancement 2
+- Enhancement 2 (1.1.0)
+"""
+        )

--- a/tests/test_changelog_unreleased.py
+++ b/tests/test_changelog_unreleased.py
@@ -90,6 +90,7 @@ def test_changelog_with_versions_and_all_categories(changelog):
             "security": ["Known issue 1", "Known issue 2"],
             "deprecated": ["Deprecated feature 1", "Future removal 2"],
             "removed": ["Deprecated feature 2", "Future removal 1"],
+            "url": "https://github.test_url/test_project/compare/v1.1.0...HEAD",
         },
         "1.1.0": {
             "version": "1.1.0",
@@ -100,6 +101,7 @@ def test_changelog_with_versions_and_all_categories(changelog):
                 "sub enhancement 2",
                 "Enhancement 2 (1.1.0)",
             ],
+            "url": "https://github.test_url/test_project/compare/v1.0.1...v1.1.0",
         },
         "1.0.1": {
             "version": "1.0.1",
@@ -110,10 +112,12 @@ def test_changelog_with_versions_and_all_categories(changelog):
                 "sub bug 2",
                 "Bug fix 2 (1.0.1)",
             ],
+            "url": "https://github.test_url/test_project/compare/v1.0.0...v1.0.1",
         },
         "1.0.0": {
             "version": "1.0.0",
             "release_date": "2017-04-10",
             "deprecated": ["Known issue 1 (1.0.0)", "Known issue 2 (1.0.0)"],
+            "url": "https://github.test_url/test_project/releases/tag/v1.0.0",
         },
     }

--- a/tests/test_changelog_unreleased.py
+++ b/tests/test_changelog_unreleased.py
@@ -94,6 +94,13 @@ def test_changelog_with_versions_and_all_categories(changelog):
         },
         "1.1.0": {
             "version": "1.1.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 1,
+                "patch": 0,
+                "prerelease": None,
+            },
             "release_date": "2018-05-31",
             "changed": [
                 "Enhancement 1 (1.1.0)",
@@ -105,6 +112,13 @@ def test_changelog_with_versions_and_all_categories(changelog):
         },
         "1.0.1": {
             "version": "1.0.1",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 1,
+                "prerelease": None,
+            },
             "release_date": "2018-05-31",
             "fixed": [
                 "Bug fix 1 (1.0.1)",
@@ -116,6 +130,13 @@ def test_changelog_with_versions_and_all_categories(changelog):
         },
         "1.0.0": {
             "version": "1.0.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 0,
+                "prerelease": None,
+            },
             "release_date": "2017-04-10",
             "deprecated": ["Known issue 1 (1.0.0)", "Known issue 2 (1.0.0)"],
             "url": "https://github.test_url/test_project/releases/tag/v1.0.0",

--- a/tests/test_flask_restx.py
+++ b/tests/test_flask_restx.py
@@ -87,6 +87,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
                 ],
                 "release_date": "2018-05-31",
                 "version": "1.1.0",
+                "url": "https://github.test_url/test_project/compare/v1.0.1...v1.1.0",
             },
             "1.0.1": {
                 "fixed": [
@@ -97,11 +98,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
                 ],
                 "release_date": "2018-05-31",
                 "version": "1.0.1",
+                "url": "https://github.test_url/test_project/compare/v1.0.0...v1.0.1",
             },
             "1.0.0": {
                 "deprecated": ["Known issue 1 (1.0.0)", "Known issue 2 (1.0.0)"],
                 "release_date": "2017-04-10",
                 "version": "1.0.0",
+                "url": "https://github.test_url/test_project/releases/tag/v1.0.0",
             },
         }
 

--- a/tests/test_flask_restx.py
+++ b/tests/test_flask_restx.py
@@ -87,6 +87,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
                 ],
                 "release_date": "2018-05-31",
                 "version": "1.1.0",
+                "semantic_version": {
+                    "buildmetadata": None,
+                    "major": 1,
+                    "minor": 1,
+                    "patch": 0,
+                    "prerelease": None,
+                },
                 "url": "https://github.test_url/test_project/compare/v1.0.1...v1.1.0",
             },
             "1.0.1": {
@@ -98,12 +105,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
                 ],
                 "release_date": "2018-05-31",
                 "version": "1.0.1",
+                "semantic_version": {
+                    "buildmetadata": None,
+                    "major": 1,
+                    "minor": 0,
+                    "patch": 1,
+                    "prerelease": None,
+                },
                 "url": "https://github.test_url/test_project/compare/v1.0.0...v1.0.1",
             },
             "1.0.0": {
                 "deprecated": ["Known issue 1 (1.0.0)", "Known issue 2 (1.0.0)"],
                 "release_date": "2017-04-10",
                 "version": "1.0.0",
+                "semantic_version": {
+                    "buildmetadata": None,
+                    "major": 1,
+                    "minor": 0,
+                    "patch": 0,
+                    "prerelease": None,
+                },
                 "url": "https://github.test_url/test_project/releases/tag/v1.0.0",
             },
         }

--- a/tests/test_non_standard_changelog.py
+++ b/tests/test_non_standard_changelog.py
@@ -87,6 +87,13 @@ def test_changelog_with_versions_and_all_categories(changelog):
             "removed": ["Deprecated feature 2", "Future removal 1"],
             "security": ["Known issue 1", "Known issue 2"],
             "version": "1.2.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 2,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
         "1.1.0": {
             "changed": [
@@ -97,6 +104,13 @@ def test_changelog_with_versions_and_all_categories(changelog):
             ],
             "release_date": "may 03, 2018",
             "version": "1.1.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 1,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
         "1.0.1": {
             "fixed": [
@@ -107,11 +121,25 @@ def test_changelog_with_versions_and_all_categories(changelog):
             ],
             "release_date": "may 01, 2018",
             "version": "1.0.1",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 1,
+                "prerelease": None,
+            },
         },
         "1.0.0": {
             "deprecated": ["Known issue 1 (1.0.0)", "Known issue 2 (1.0.0)"],
             "release_date": "2017-01-01",
             "version": "1.0.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
     }
 
@@ -133,6 +161,13 @@ def test_changelog_with_unreleased_versions_and_all_categories(changelog):
             "removed": ["Deprecated feature 2", "Future removal 1"],
             "security": ["Known issue 1", "Known issue 2"],
             "version": "1.2.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 2,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
         "1.1.0": {
             "changed": [
@@ -143,6 +178,13 @@ def test_changelog_with_unreleased_versions_and_all_categories(changelog):
             ],
             "release_date": "may 03, 2018",
             "version": "1.1.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 1,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
         "1.0.1": {
             "fixed": [
@@ -153,11 +195,25 @@ def test_changelog_with_unreleased_versions_and_all_categories(changelog):
             ],
             "release_date": "may 01, 2018",
             "version": "1.0.1",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 1,
+                "prerelease": None,
+            },
         },
         "1.0.0": {
             "deprecated": ["Known issue 1 (1.0.0)", "Known issue 2 (1.0.0)"],
             "release_date": "2017-01-01",
             "version": "1.0.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
     }
 
@@ -190,6 +246,13 @@ def test_raw_changelog_with_versions_and_all_categories(changelog):
 """,
             "release_date": "august 28, 2019",
             "version": "1.2.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 2,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
         "1.1.0": {
             "raw": """### Changed
@@ -200,6 +263,13 @@ def test_raw_changelog_with_versions_and_all_categories(changelog):
 """,
             "release_date": "may 03, 2018",
             "version": "1.1.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 1,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
         "1.0.1": {
             "raw": """### Fixed
@@ -210,6 +280,13 @@ def test_raw_changelog_with_versions_and_all_categories(changelog):
 """,
             "release_date": "may 01, 2018",
             "version": "1.0.1",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 1,
+                "prerelease": None,
+            },
         },
         "1.0.0": {
             "raw": """### Deprecated
@@ -218,5 +295,12 @@ def test_raw_changelog_with_versions_and_all_categories(changelog):
 """,
             "release_date": "2017-01-01",
             "version": "1.0.0",
+            "semantic_version": {
+                "buildmetadata": None,
+                "major": 1,
+                "minor": 0,
+                "patch": 0,
+                "prerelease": None,
+            },
         },
     }

--- a/tests/test_starlette.py
+++ b/tests/test_starlette.py
@@ -86,6 +86,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
                 ],
                 "release_date": "2018-05-31",
                 "version": "1.1.0",
+                "semantic_version": {
+                    "buildmetadata": None,
+                    "major": 1,
+                    "minor": 1,
+                    "patch": 0,
+                    "prerelease": None,
+                },
                 "url": "https://github.test_url/test_project/compare/v1.0.1...v1.1.0",
             },
             "1.0.1": {
@@ -97,12 +104,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
                 ],
                 "release_date": "2018-05-31",
                 "version": "1.0.1",
+                "semantic_version": {
+                    "buildmetadata": None,
+                    "major": 1,
+                    "minor": 0,
+                    "patch": 1,
+                    "prerelease": None,
+                },
                 "url": "https://github.test_url/test_project/compare/v1.0.0...v1.0.1",
             },
             "1.0.0": {
                 "deprecated": ["Known issue 1 (1.0.0)", "Known issue 2 (1.0.0)"],
                 "release_date": "2017-04-10",
                 "version": "1.0.0",
+                "semantic_version": {
+                    "buildmetadata": None,
+                    "major": 1,
+                    "minor": 0,
+                    "patch": 0,
+                    "prerelease": None,
+                },
                 "url": "https://github.test_url/test_project/releases/tag/v1.0.0",
             },
         }

--- a/tests/test_starlette.py
+++ b/tests/test_starlette.py
@@ -86,6 +86,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
                 ],
                 "release_date": "2018-05-31",
                 "version": "1.1.0",
+                "url": "https://github.test_url/test_project/compare/v1.0.1...v1.1.0",
             },
             "1.0.1": {
                 "fixed": [
@@ -96,11 +97,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
                 ],
                 "release_date": "2018-05-31",
                 "version": "1.0.1",
+                "url": "https://github.test_url/test_project/compare/v1.0.0...v1.0.1",
             },
             "1.0.0": {
                 "deprecated": ["Known issue 1 (1.0.0)", "Known issue 2 (1.0.0)"],
                 "release_date": "2017-04-10",
                 "version": "1.0.0",
+                "url": "https://github.test_url/test_project/releases/tag/v1.0.0",
             },
         }
 


### PR DESCRIPTION
### Changed
- `keepachangelog.to_dict` now contains `url` key for each item if a link is available for the version.
- `keepachangelog.to_raw_dict` now contains `url` key for each item if a link is available for the version.
- `keepachangelog.to_dict` now contains `semantic_version` key for each item if the version follows semantic versioning.
- `keepachangelog.to_raw_dict` now contains `semantic_version` key for each item if the version follows semantic versioning.

### Added
- `keepachangelog.release` is now allowing to provide a custom new version thanks to the new `new_version` parameter.

### Fixed
- `keepachangelog.release` now allows `pre-release` and `build metadata` information as part of valid semantic version. As per [semantic versioning specifications](https://semver.org). 
  To ensure compatibility with some python specific versioning, `pre-release` is also handled as not being prefixed with `-`, or prefixed with `.`.
- `keepachangelog.release` will now bump a pre-release version to a stable version. It was previously failing.
