### PR TITLE
Release 2.0.0.dev1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0.dev1] - 2021-05-27
+### Changed
+- `keepachangelog.release` will now return `None` instead of throwing an exception if there is no Unreleased content.
+
 ## [2.0.0.dev0] - 2021-05-27
 ### Fixed
 - `keepachangelog.to_dict` now contains releases that have a URL but no section.
@@ -73,7 +77,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Initial release.
 
-[Unreleased]: https://github.com/Colin-b/keepachangelog/compare/v2.0.0.dev0...HEAD
+[Unreleased]: https://github.com/Colin-b/keepachangelog/compare/v2.0.0.dev1...HEAD
+[2.0.0.dev1]: https://github.com/Colin-b/keepachangelog/compare/v2.0.0.dev0...v2.0.0.dev1
 [2.0.0.dev0]: https://github.com/Colin-b/keepachangelog/compare/v1.0.0...v2.0.0.dev0
 [1.0.0]: https://github.com/Colin-b/keepachangelog/compare/v0.5.0...v1.0.0
 [0.5.0]: https://github.com/Colin-b/keepachangelog/compare/v0.4.0...v0.5.0

--- a/keepachangelog/_changelog.py
+++ b/keepachangelog/_changelog.py
@@ -205,12 +205,20 @@ def to_raw_dict(changelog_path: str) -> Dict[str, dict]:
     return changes
 
 
-def release(changelog_path: str, new_version: str = None) -> str:
+def release(changelog_path: str, new_version: str = None) -> Optional[str]:
+    """
+    Release a new version based on changelog unreleased content.
+
+    :param changelog_path: Path to the changelog file.
+    :param new_version: The new version to use instead of trying to guess one.
+    :return: The new version, None if there was no change to release.
+    """
     changelog = to_dict(changelog_path, show_unreleased=True)
     current_version, current_semantic_version = actual_version(changelog)
     if not new_version:
         new_version = guess_unreleased_version(changelog, current_semantic_version)
-    release_version(changelog_path, current_version, new_version)
+    if new_version:
+        release_version(changelog_path, current_version, new_version)
     return new_version
 
 

--- a/keepachangelog/_versioning.py
+++ b/keepachangelog/_versioning.py
@@ -81,17 +81,15 @@ def actual_version(changelog: dict) -> Tuple[Optional[str], dict]:
     return versions.pop() if versions else (None, initial_semantic_version.copy())
 
 
-def guess_unreleased_version(changelog: dict, current_semantic_version: dict) -> str:
+def guess_unreleased_version(
+    changelog: dict, current_semantic_version: dict
+) -> Optional[str]:
     unreleased = changelog.get("unreleased", {})
     # Only keep user provided entries
     unreleased = unreleased.copy()
     unreleased.pop("metadata", None)
-    if not unreleased:
-        raise Exception(
-            "Release content must be provided within changelog Unreleased section."
-        )
-
-    return from_semantic(bump(unreleased, current_semantic_version))
+    if unreleased:
+        return from_semantic(bump(unreleased, current_semantic_version))
 
 
 semantic_versioning = re.compile(

--- a/keepachangelog/version.py
+++ b/keepachangelog/version.py
@@ -3,4 +3,4 @@
 # Major should be incremented in case there is a breaking change. (eg: 2.5.8 -> 3.0.0)
 # Minor should be incremented in case there is an enhancement. (eg: 2.5.8 -> 2.6.0)
 # Patch should be incremented in case there is a bug fix. (eg: 2.5.8 -> 2.5.9)
-__version__ = "2.0.0.dev0"
+__version__ = "2.0.0.dev1"

--- a/tests/test_changelog_release.py
+++ b/tests/test_changelog_release.py
@@ -726,21 +726,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 
 def test_empty_release(empty_changelog):
-    with pytest.raises(Exception) as exception_info:
-        keepachangelog.release(empty_changelog)
-    assert (
-        str(exception_info.value)
-        == "Release content must be provided within changelog Unreleased section."
-    )
+    assert not keepachangelog.release(empty_changelog)
 
 
 def test_empty_unreleased_release(empty_unreleased_changelog):
-    with pytest.raises(Exception) as exception_info:
-        keepachangelog.release(empty_unreleased_changelog)
-    assert (
-        str(exception_info.value)
-        == "Release content must be provided within changelog Unreleased section."
-    )
+    assert not keepachangelog.release(empty_unreleased_changelog)
 
 
 def test_non_semantic_release(non_semantic_changelog):


### PR DESCRIPTION
### Changed
- `keepachangelog.release` will now return `None` instead of throwing an exception if there is no Unreleased content.
