### PR TITLE
[Feature] Add a CLI feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-- Add a CLI
+- Add a CLI to interact with `keepachangelog` API
 
 ## [2.0.0.dev2] - 2021-08-04
 ### Fixed
@@ -46,7 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `keepachangelog.release` is now allowing to provide a custom new version thanks to the new `new_version` parameter.
 
 ### Fixed
-- `keepachangelog.release` now allows `pre-release` and `build metadata` information as part of valid semantic version. As per [semantic versioning specifications](https://semver.org). 
+- `keepachangelog.release` now allows `pre-release` and `build metadata` information as part of valid semantic version. As per [semantic versioning specifications](https://semver.org).
   To ensure compatibility with some python specific versioning, `pre-release` is also handled as not being prefixed with `-`, or prefixed with `.`.
 - `keepachangelog.release` will now bump a pre-release version to a stable version. It was previously failing.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add a CLI
 
 ## [2.0.0.dev2] - 2021-08-04
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -299,3 +299,14 @@ Note: [flask-restx](https://pypi.python.org/pypi/flask-restx) module must be ins
 ```sh
 python -m pip install keepachangelog
 ```
+
+## Usage from command line
+
+`keepachangelog` can be used directly via command line:
+
+```sh
+# Run it as a Python module
+python -m keepachangelog --help
+# or as a shell command
+keepachangelog --help
+```

--- a/README.md
+++ b/README.md
@@ -309,4 +309,27 @@ python -m pip install keepachangelog
 python -m keepachangelog --help
 # or as a shell command
 keepachangelog --help
+
+# usage: keepachangelog [-h] [-v] {show,release} ...
+#
+# Manipulate keep a changelog files
+#
+# options:
+#   -h, --help      show this help message and exit
+#   -v, --version   show program's version number and exit
+#
+# commands:
+#   {show,release}
+#     show          Show the content of a release from the changelog
+#     release       Create a new release in the changelog
+#
+# Examples:
+#
+#     keepachangelog show 1.0.0
+#     keepachangelog show 1.0.0 --raw
+#     keepachangelog show 1.0.0 path/to/CHANGELOG.md
+#
+#     keepachangelog release
+#     keepachangelog release 1.0.1
+#     keepachangelog release 1.0.1 -f path/to/CHANGELOG.md
 ```

--- a/keepachangelog/__main__.py
+++ b/keepachangelog/__main__.py
@@ -6,7 +6,7 @@ from keepachangelog.version import __version__
 
 
 def _format_change_section(change_type: str, changes: List[str]):
-    body = "".join([ f"  - {change}\r\n" for change in changes ])
+    body = "".join([f"  - {change}\r\n" for change in changes])
 
     return f"""{change_type.capitalize()}
 {body}"""
@@ -38,12 +38,17 @@ def _command_show(args):
 
 def _command_release(args):
     new_version = keepachangelog.release(args.file, args.release)
-    
+
     if new_version:
         print(new_version)
 
 
 def _parse_args():
+    class CustomFormatter(
+        argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter
+    ):
+        pass
+
     parser = argparse.ArgumentParser(
         prog="keepachangelog",
         description="Manipulate keep a changelog files",
@@ -58,19 +63,25 @@ Examples:
     keepachangelog release 1.0.1
     keepachangelog release 1.0.1 -f path/to/CHANGELOG.md
 """,
+        formatter_class=CustomFormatter,
     )
 
     subparser = parser.add_subparsers(title="commands")
 
     # keepachangelog show
-    parser_show: argparse.ArgumentParser = subparser.add_parser("show")
+    parser_show_help = "Show the content of a release from the changelog"
+    parser_show: argparse.ArgumentParser = subparser.add_parser("show", description=parser_show_help, help=parser_show_help)
+    parser_show.formatter_class = CustomFormatter
 
-    parser_show.add_argument("release", help="The version to search in the changelog")
+    parser_show.add_argument(
+        "release", type=str, help="The version to search in the changelog"
+    )
     parser_show.add_argument(
         "file",
+        type=str,
         nargs="?",
         default="CHANGELOG.md",
-        help="The path to the changelog file, (default: CHANGELOG.md)",
+        help="The path to the changelog file",
     )
     parser_show.add_argument(
         "-r", "--raw", action="store_true", help="Show the raw markdown body"
@@ -79,14 +90,23 @@ Examples:
     parser_show.set_defaults(func=_command_show)
 
     # keepachangelog release
-    parser_release: argparse.ArgumentParser = subparser.add_parser("release")
-    parser_release.add_argument("release", nargs="?", help="The version to add to the changelog")
+    parser_release_help = "Create a new release in the changelog"
+    parser_release: argparse.ArgumentParser = subparser.add_parser("release", description=parser_release_help, help=parser_release_help)
+    parser_release.formatter_class = CustomFormatter
+
+    parser_release.add_argument(
+        "release",
+        type=str,
+        nargs="?",
+        help="The version to add to the changelog. If not provided, a new version will be automatically generated based on the changes in the Unreleased section",
+    )
     parser_release.add_argument(
         "-f",
         "--file",
+        type=str,
         required=False,
         default="CHANGELOG.md",
-        help="The path to the changelog file, (default: CHANGELOG.md)",
+        help="The path to the changelog file",
     )
 
     parser_release.set_defaults(func=_command_release)

--- a/keepachangelog/__main__.py
+++ b/keepachangelog/__main__.py
@@ -1,0 +1,107 @@
+from typing import List
+import argparse
+
+import keepachangelog
+from keepachangelog.version import __version__
+
+
+def _format_change_section(change_type: str, changes: List[str]):
+    body = "".join([ f"  - {change}\r\n" for change in changes ])
+
+    return f"""{change_type.capitalize()}
+{body}"""
+
+
+def _command_show(args):
+    output = None
+
+    if args.raw:
+        changelog = keepachangelog.to_raw_dict(args.file)
+    else:
+        changelog = keepachangelog.to_dict(args.file)
+
+    content = changelog.get(args.release)
+
+    if args.raw:
+        output = content["raw"]
+    else:
+        output = "\n".join(
+            [
+                _format_change_section(change_type, changes)
+                for change_type, changes in content.items()
+                if change_type != "metadata"
+            ]
+        )
+
+    print(output)
+
+
+def _command_release(args):
+    new_version = keepachangelog.release(args.file, args.release)
+    
+    if new_version:
+        print(new_version)
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        prog="keepachangelog",
+        description="Manipulate keep a changelog files",
+        epilog="""
+Examples:
+
+    keepachangelog show 1.0.0
+    keepachangelog show 1.0.0 --raw
+    keepachangelog show 1.0.0 path/to/CHANGELOG.md
+
+    keepachangelog release
+    keepachangelog release 1.0.1
+    keepachangelog release 1.0.1 -f path/to/CHANGELOG.md
+""",
+    )
+
+    subparser = parser.add_subparsers(title="commands")
+
+    # keepachangelog show
+    parser_show: argparse.ArgumentParser = subparser.add_parser("show")
+
+    parser_show.add_argument("release", help="The version to search in the changelog")
+    parser_show.add_argument(
+        "file",
+        nargs="?",
+        default="CHANGELOG.md",
+        help="The path to the changelog file, (default: CHANGELOG.md)",
+    )
+    parser_show.add_argument(
+        "-r", "--raw", action="store_true", help="Show the raw markdown body"
+    )
+
+    parser_show.set_defaults(func=_command_show)
+
+    # keepachangelog release
+    parser_release: argparse.ArgumentParser = subparser.add_parser("release")
+    parser_release.add_argument("release", nargs="?", help="The version to add to the changelog")
+    parser_release.add_argument(
+        "-f",
+        "--file",
+        required=False,
+        default="CHANGELOG.md",
+        help="The path to the changelog file, (default: CHANGELOG.md)",
+    )
+
+    parser_release.set_defaults(func=_command_release)
+
+    parser.add_argument(
+        "--version", action="version", version=f"%(prog)s {__version__}"
+    )
+
+    return parser.parse_args()
+
+
+def main(args=None):
+    args = _parse_args()
+    args.func(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/keepachangelog/__main__.py
+++ b/keepachangelog/__main__.py
@@ -43,7 +43,7 @@ def _command_release(args):
         print(new_version)
 
 
-def _parse_args():
+def _parse_args(cmdline: List[str]):
     class CustomFormatter(
         argparse.ArgumentDefaultsHelpFormatter, argparse.RawDescriptionHelpFormatter
     ):
@@ -70,7 +70,9 @@ Examples:
 
     # keepachangelog show
     parser_show_help = "Show the content of a release from the changelog"
-    parser_show: argparse.ArgumentParser = subparser.add_parser("show", description=parser_show_help, help=parser_show_help)
+    parser_show: argparse.ArgumentParser = subparser.add_parser(
+        "show", description=parser_show_help, help=parser_show_help
+    )
     parser_show.formatter_class = CustomFormatter
 
     parser_show.add_argument(
@@ -91,7 +93,9 @@ Examples:
 
     # keepachangelog release
     parser_release_help = "Create a new release in the changelog"
-    parser_release: argparse.ArgumentParser = subparser.add_parser("release", description=parser_release_help, help=parser_release_help)
+    parser_release: argparse.ArgumentParser = subparser.add_parser(
+        "release", description=parser_release_help, help=parser_release_help
+    )
     parser_release.formatter_class = CustomFormatter
 
     parser_release.add_argument(
@@ -112,14 +116,14 @@ Examples:
     parser_release.set_defaults(func=_command_release)
 
     parser.add_argument(
-        "--version", action="version", version=f"%(prog)s {__version__}"
+        "-v", "--version", action="version", version=f"%(prog)s {__version__}"
     )
 
-    return parser.parse_args()
+    return parser.parse_args(cmdline)
 
 
-def main(args=None):
-    args = _parse_args()
+def main(cmdline=None):
+    args = _parse_args(cmdline)
     args.func(args)
 
 

--- a/keepachangelog/__main__.py
+++ b/keepachangelog/__main__.py
@@ -128,4 +128,4 @@ def main(cmdline=None):
 
 
 if __name__ == "__main__":
-    main()
+    main()  # pragma: no cover

--- a/keepachangelog/__main__.py
+++ b/keepachangelog/__main__.py
@@ -122,7 +122,7 @@ Examples:
     return parser.parse_args(cmdline)
 
 
-def main(cmdline=None):
+def main(cmdline: List[str] = None):
     args = _parse_args(cmdline)
     args.func(args)
 

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "Issues": "https://github.com/Colin-b/keepachangelog/issues",
     },
     platforms=["Windows", "Linux"],
-    entry_points = {
-        'console_scripts': ['keepachangelog=keepachangelog.__main__:main'],
+    entry_points={
+        "console_scripts": ["keepachangelog=keepachangelog.__main__:main"],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -55,4 +55,7 @@ setup(
         "Issues": "https://github.com/Colin-b/keepachangelog/issues",
     },
     platforms=["Windows", "Linux"],
+    entry_points = {
+        'console_scripts': ['keepachangelog=keepachangelog.__main__:main'],
+    },
 )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,6 +18,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Breaking change
 
 ## [1.2.0] - 2018-06-01
 ### Changed
@@ -67,15 +69,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     return changelog_file_path
 
 
-# keepachangelog show 1.0.0
-# keepachangelog show 1.0.0 --raw
-# keepachangelog show 1.0.0 path/to/CHANGELOG.md
-#
-# keepachangelog release
-# keepachangelog release 1.0.1
-# keepachangelog release 1.0.1 -f path/to/CHANGELOG.md
-
-
 def test_print_help(changelog: str, capsys: pytest.CaptureFixture):
     with pytest.raises(SystemExit) as exc:
         cli(["--help"])
@@ -97,7 +90,7 @@ def test_print_version(changelog: str, capsys: pytest.CaptureFixture):
     captured = capsys.readouterr()
 
     assert captured.err is ""
-    assert captured.out == f"keepachangelog {__version__}\n"
+    assert captured.out.strip() == f"keepachangelog {__version__}"
 
 
 def test_show_release_pretty(changelog: str, capsys: pytest.CaptureFixture):
@@ -105,9 +98,42 @@ def test_show_release_pretty(changelog: str, capsys: pytest.CaptureFixture):
 
     captured = capsys.readouterr()
 
-    print(captured.out)
     assert captured.err is ""
     assert (
-        captured.out
-        == "Deprecated\n  - Known issue 1 (1.0.0)\r\n  - Known issue 2 (1.0.0)\r\n\n"
+        captured.out.strip()
+        == "Deprecated\n  - Known issue 1 (1.0.0)\r\n  - Known issue 2 (1.0.0)"
     )
+
+
+def test_show_release_raw(changelog: str, capsys: pytest.CaptureFixture):
+    cli(["show", "1.0.0", changelog, "--raw"])
+
+    captured = capsys.readouterr()
+
+    assert captured.err is ""
+    assert (
+        captured.out.strip()
+        == """### Deprecated
+- Known issue 1 (1.0.0)
+- Known issue 2 (1.0.0)"""
+    )
+
+
+def test_create_release_automatic_version(
+    changelog: str, capsys: pytest.CaptureFixture
+):
+    cli(["release", "-f", changelog])
+
+    captured = capsys.readouterr()
+
+    assert captured.err is ""
+    assert captured.out.strip() == "2.0.0"
+
+
+def test_create_release_specific_version(changelog: str, capsys: pytest.CaptureFixture):
+    cli(["release", "3.2.1", "-f", changelog])
+
+    captured = capsys.readouterr()
+
+    assert captured.err is ""
+    assert captured.out.strip() == "3.2.1"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,113 @@
+import os
+
+import pytest
+
+from keepachangelog.__main__ import main as cli
+from keepachangelog.version import __version__
+
+
+@pytest.fixture
+def changelog(tmpdir):
+    changelog_file_path = os.path.join(tmpdir, "CHANGELOG.md")
+    with open(changelog_file_path, "wt") as file:
+        file.write(
+            """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.2.0] - 2018-06-01
+### Changed
+- Release note 1.
+- Release note 2.
+
+### Added
+- Enhancement 1
+- sub enhancement 1
+- sub enhancement 2
+- Enhancement 2
+
+### Fixed
+- Bug fix 1
+- sub bug 1
+- sub bug 2
+- Bug fix 2
+
+### Security
+- Known issue 1
+- Known issue 2
+
+### Deprecated
+- Deprecated feature 1
+- Future removal 2
+
+## [1.1.0] - 2018-05-31
+### Changed
+- Enhancement 1 (1.1.0)
+- sub enhancement 1
+- sub enhancement 2
+- Enhancement 2 (1.1.0)
+
+## [1.0.1] - 2018-05-31
+### Fixed
+- Bug fix 1 (1.0.1)
+- sub bug 1
+- sub bug 2
+- Bug fix 2 (1.0.1)
+
+## [1.0.0] - 2017-04-10
+### Deprecated
+- Known issue 1 (1.0.0)
+- Known issue 2 (1.0.0)
+"""
+        )
+    return changelog_file_path
+
+
+# keepachangelog show 1.0.0
+# keepachangelog show 1.0.0 --raw
+# keepachangelog show 1.0.0 path/to/CHANGELOG.md
+#
+# keepachangelog release
+# keepachangelog release 1.0.1
+# keepachangelog release 1.0.1 -f path/to/CHANGELOG.md
+
+
+def test_print_help(changelog: str, capsys: pytest.CaptureFixture):
+    with pytest.raises(SystemExit) as exc:
+        cli(["--help"])
+
+    assert exc.value.args[0] == 0
+
+    captured = capsys.readouterr()
+
+    assert captured.err is ""
+    assert "usage: keepachangelog [-h] [-v] {show,release} ..." in captured.out
+
+
+def test_print_version(changelog: str, capsys: pytest.CaptureFixture):
+    with pytest.raises(SystemExit) as exc:
+        cli(["--version"])
+
+    assert exc.value.args[0] == 0
+
+    captured = capsys.readouterr()
+
+    assert captured.err is ""
+    assert captured.out == f"keepachangelog {__version__}\n"
+
+
+def test_show_release_pretty(changelog: str, capsys: pytest.CaptureFixture):
+    cli(["show", "1.0.0", changelog])
+
+    captured = capsys.readouterr()
+
+    print(captured.out)
+    assert captured.err is ""
+    assert (
+        captured.out
+        == "Deprecated\n  - Known issue 1 (1.0.0)\r\n  - Known issue 2 (1.0.0)\r\n\n"
+    )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -77,7 +77,7 @@ def test_print_help(changelog: str, capsys: pytest.CaptureFixture):
 
     captured = capsys.readouterr()
 
-    assert captured.err is ""
+    assert captured.err == ""
     assert "usage: keepachangelog [-h] [-v] {show,release} ..." in captured.out
 
 
@@ -89,7 +89,7 @@ def test_print_version(changelog: str, capsys: pytest.CaptureFixture):
 
     captured = capsys.readouterr()
 
-    assert captured.err is ""
+    assert captured.err == ""
     assert captured.out.strip() == f"keepachangelog {__version__}"
 
 
@@ -98,7 +98,7 @@ def test_show_release_pretty(changelog: str, capsys: pytest.CaptureFixture):
 
     captured = capsys.readouterr()
 
-    assert captured.err is ""
+    assert captured.err == ""
     assert (
         captured.out.strip()
         == "Deprecated\n  - Known issue 1 (1.0.0)\r\n  - Known issue 2 (1.0.0)"
@@ -110,7 +110,7 @@ def test_show_release_raw(changelog: str, capsys: pytest.CaptureFixture):
 
     captured = capsys.readouterr()
 
-    assert captured.err is ""
+    assert captured.err == ""
     assert (
         captured.out.strip()
         == """### Deprecated
@@ -126,7 +126,7 @@ def test_create_release_automatic_version(
 
     captured = capsys.readouterr()
 
-    assert captured.err is ""
+    assert captured.err == ""
     assert captured.out.strip() == "2.0.0"
 
 
@@ -135,5 +135,5 @@ def test_create_release_specific_version(changelog: str, capsys: pytest.CaptureF
 
     captured = capsys.readouterr()
 
-    assert captured.err is ""
+    assert captured.err == ""
     assert captured.out.strip() == "3.2.1"


### PR DESCRIPTION
Allows `keepachangelog` to be used via command line:

```sh
# Run it as a Python module
python -m keepachangelog --help
# or as a shell command
keepachangelog --help
```

There are 2 main commands, `show` to print a release body and `release` to create a new release.
Here some examples of how to use the CLI:

```sh
# show
keepachangelog show 1.0.0
keepachangelog show 1.0.0 --raw
keepachangelog show 1.0.0 path/to/CHANGELOG.md

# release
keepachangelog release
keepachangelog release 1.0.1
keepachangelog release 1.0.1 -f path/to/CHANGELOG.md
```

## Motivations

The main reason behind this PR is to use `keepachange` in a CI/CD environment for creating releases in GitHub or GitLab, that is, think about running something `GITHUB_RELEASE_BODY=$(keepachangelog show ${GIT_TAG} --raw)` and creating a release via GitHub API.

The CLI is also useful for creating new releases just running `keepachangelog release`.