### PR TITLE
Do not release same version twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Do not release same version twice.
 
 ## [2.0.0] - 2024-06-14
 ### Removed

--- a/keepachangelog/__main__.py
+++ b/keepachangelog/__main__.py
@@ -3,6 +3,7 @@ import argparse
 
 import keepachangelog
 from keepachangelog.version import __version__
+from keepachangelog._versioning import VersionAlreadyReleasedError
 
 
 def _command_show(args: argparse.Namespace) -> None:
@@ -12,7 +13,11 @@ def _command_show(args: argparse.Namespace) -> None:
 
 
 def _command_release(args: argparse.Namespace) -> None:
-    new_version = keepachangelog.release(args.file, args.release)
+    try:
+        new_version = keepachangelog.release(args.file, args.release)
+    except VersionAlreadyReleasedError as ex:
+            sys.stderr.write(ex.args[0])
+            exit(3)
 
     if not new_version:
         sys.stderr.write(

--- a/keepachangelog/_changelog.py
+++ b/keepachangelog/_changelog.py
@@ -7,6 +7,7 @@ from keepachangelog._versioning import (
     guess_unreleased_version,
     to_semantic,
     InvalidSemanticVersion,
+    VersionAlreadyReleasedError,
 )
 
 
@@ -218,7 +219,10 @@ def release(changelog_path: str, new_version: str = None) -> Optional[str]:
     """
     changelog = to_dict(changelog_path, show_unreleased=True)
     current_version, current_semantic_version = actual_version(changelog)
-    if not new_version:
+    if new_version:
+        if new_version in changelog.keys():
+            raise VersionAlreadyReleasedError(new_version)
+    else:
         new_version = guess_unreleased_version(changelog, current_semantic_version)
     if new_version:
         release_version(changelog_path, current_version, new_version)

--- a/keepachangelog/_versioning.py
+++ b/keepachangelog/_versioning.py
@@ -18,6 +18,13 @@ class InvalidSemanticVersion(Exception):
         )
 
 
+class VersionAlreadyReleasedError(Exception):
+    def __init__(self, version: str):
+        super().__init__(
+            f"Version {version} already released."
+        )
+
+
 def contains_breaking_changes(unreleased: dict) -> bool:
     return "removed" in unreleased or "changed" in unreleased
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -156,6 +156,17 @@ def test_create_release_nothing_to_release(
     assert captured.out == ""
 
 
+def test_create_release_already_exists(changelog: str, capsys: pytest.CaptureFixture):
+    with pytest.raises(SystemExit) as cm:
+        cli(["release", "1.1.0", "-f", changelog])
+    assert cm.value.code == 3
+
+    captured = capsys.readouterr()
+
+    assert captured.err == "Version 1.1.0 already released."
+    assert captured.out == ""
+
+
 def test_create_release_specific_version(changelog: str, capsys: pytest.CaptureFixture):
     cli(["release", "3.2.1", "-f", changelog])
 


### PR DESCRIPTION
It was possible to run `keepachangelog release 2.0.0` multiple times.
Each time the CHANGELOG.md was updated with text for yet-another 2.0.0 release.

PR prevents this, and error message like "Version 2.0.0 already released." is shown.
