### PR TITLE
Cli missing params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Show helpful error message if `show <release>` does not find requested `release`.
 
 ## [2.0.0] - 2024-06-14
 ### Removed

--- a/keepachangelog/__main__.py
+++ b/keepachangelog/__main__.py
@@ -45,7 +45,7 @@ Examples:
         formatter_class=CustomFormatter,
     )
 
-    subparser = parser.add_subparsers(title="commands")
+    subparser = parser.add_subparsers(title="commands", required=True)
 
     # keepachangelog show
     parser_show_help = "Show the content of a release from the changelog"

--- a/keepachangelog/__main__.py
+++ b/keepachangelog/__main__.py
@@ -7,6 +7,13 @@ from keepachangelog.version import __version__
 
 def _command_show(args: argparse.Namespace) -> None:
     changelog = keepachangelog.to_raw_dict(args.file)
+
+    if args.release not in changelog.keys():
+        sys.stderr.write(
+            f"{args.file} does not contain release {args.release}."
+        )
+        exit(3)
+
     content = changelog.get(args.release)
     print(content["raw"])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -129,6 +129,18 @@ def test_show_release_raw(changelog: str, capsys: pytest.CaptureFixture):
     )
 
 
+def test_show_release_does_not_exist(changelog: str, capsys: pytest.CaptureFixture):
+    # Requested release does not exist.
+    with pytest.raises(SystemExit) as cm:
+        cli(["show", "11.0.0", changelog])
+    assert cm.value.code == 3
+
+    captured = capsys.readouterr()
+
+    assert captured.err.strip() == f"{changelog} does not contain release 11.0.0."
+    assert captured.out == ""
+
+
 def test_create_release_automatic_version(
     changelog: str, capsys: pytest.CaptureFixture
 ):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -163,3 +163,18 @@ def test_create_release_specific_version(changelog: str, capsys: pytest.CaptureF
 
     assert captured.err == ""
     assert captured.out.strip() == "3.2.1"
+
+
+def test_missing_command(capsys: pytest.CaptureFixture):
+    with pytest.raises(SystemExit) as cm:
+        cli([])
+    assert cm.value.code == 2
+
+    captured = capsys.readouterr()
+
+    assert (
+        captured.err.strip()
+        == """usage: keepachangelog [-h] [-v] {show,release} ...
+keepachangelog: error: the following arguments are required: {show,release}"""
+    )
+    assert captured.out == ""


### PR DESCRIPTION
Run `keepachangelog`, and got a stacktrace. Stacktrace sounds like 'this is a bug', but I only forgot to add ` show` or ` release`.
"Fix" by showing help message about missing arguments.

Run `keepachangelog show X.Y.Z` where `X.Y.Z` is not present, and got a stacktrace. Again show error message what is wrong.