### PR TITLE
Add show_unreleased to to_raw_dict, also CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `Python` `3.13` is now explicitly supported.
+- `show_unreleased` optional argument to `to_raw_dict`
+- `keepachangelog show` option to include unreleased info: `-u` `--show-unreleased`
 
 ## [2.0.0] - 2024-06-14
 ### Removed

--- a/keepachangelog/__main__.py
+++ b/keepachangelog/__main__.py
@@ -7,7 +7,7 @@ from keepachangelog._versioning import VersionAlreadyReleasedError
 
 
 def _command_show(args: argparse.Namespace) -> None:
-    changelog = keepachangelog.to_raw_dict(args.file)
+    changelog = keepachangelog.to_raw_dict(args.file, show_unreleased=args.show_unreleased)
 
     if args.release not in changelog.keys():
         sys.stderr.write(f"{args.file} does not contain release {args.release}.")
@@ -73,6 +73,13 @@ Examples:
         nargs="?",
         default="CHANGELOG.md",
         help="The path to the changelog file",
+    )
+    parser_show.add_argument(
+        "-u",
+        "--show-unreleased",
+        action='store_true',
+        required=False,
+        help="Also include the unreleased entry",
     )
 
     parser_show.set_defaults(func=_command_show)

--- a/keepachangelog/_changelog.py
+++ b/keepachangelog/_changelog.py
@@ -174,7 +174,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     return content
 
 
-def to_raw_dict(changelog_path: str) -> dict[str, dict]:
+def to_raw_dict(changelog_path: str, show_unreleased: bool = False) -> dict[str, dict]:
     changes = {}
     # As URLs can be defined before actual usage, maintain a separate dict
     urls = {}
@@ -196,6 +196,9 @@ def to_raw_dict(changelog_path: str) -> dict[str, dict]:
         changes.setdefault(version, {"metadata": {"version": version}})["metadata"][
             "url"
         ] = url
+
+    if show_unreleased:
+        return changes
 
     unreleased_version = None
     for version, current_release in changes.items():

--- a/tests/test_changelog_unreleased.py
+++ b/tests/test_changelog_unreleased.py
@@ -252,3 +252,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [1.0.2]: https://github.test_url/test_project/compare/v1.0.1...v1.0.2
 """
     )
+
+
+def test_changelog_from_raw_dict(changelog):
+    releases = keepachangelog.to_raw_dict(changelog, show_unreleased=True)
+
+    assert (
+        releases['unreleased']['raw']
+        == """- Release note 0. 
+### Changed
+- Release note 1. 
+* Release note 2.
+### Added
+- Enhancement 1
+ - sub enhancement 1 
+ * sub enhancement 2
+- Enhancement 2
+### Fixed
+- Bug fix 1
+ - sub bug 1
+ * sub bug 2
+- Bug fix 2
+### Security
+* Known issue 1
+- Known issue 2
+### Deprecated
+- Deprecated feature 1 
+* Future removal 2
+### Removed
+- Deprecated feature 2
+* Future removal 1 
+"""
+    )


### PR DESCRIPTION
- Adds `show_released` argument to `to_raw_dict`, like in `to_dict`
- Adds command line `--show-unreleased` to `keepachangelog show`

This patch tries to maintain the same behavior, for this reason the option is disabled by default.
IMHO needing to use `keepachangelog show -u unreleased` is kind of redundant, but in this way the behavior doesn't change.