### PR TITLE
add(semver): remove 'v' prefix in release version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `Python` `3.13` is now explicitly supported.
+- handle `v` prefix in version name to convert it properly into semantic version
 
 ## [2.0.0] - 2024-06-14
 ### Removed

--- a/keepachangelog/_changelog.py
+++ b/keepachangelog/_changelog.py
@@ -1,5 +1,6 @@
 import datetime
 import re
+import logging
 from typing import Optional, Iterable, Union
 
 from keepachangelog._versioning import (
@@ -9,6 +10,8 @@ from keepachangelog._versioning import (
     InvalidSemanticVersion,
     VersionAlreadyReleasedError,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def is_release(line: str) -> bool:
@@ -29,13 +32,24 @@ def add_release(changes: dict[str, dict], line: str) -> dict:
     metadata = {"version": version, "release_date": extract_date(release_date)}
     try:
         metadata["semantic_version"] = to_semantic(version)
-    except InvalidSemanticVersion:
-        pass
+    except InvalidSemanticVersion as err:
+        if version != "unreleased":
+            logger.warning(
+                f"'{version}' does not look to comply with SemVer. Trace: {err}"
+            )
 
     return changes.setdefault(version, {"metadata": metadata})
 
 
 def unlink(value: str) -> str:
+    """Remove markdown hyperlink chars (brackets '[' ']') from release version.
+
+    Args:
+        value (str): release version name
+
+    Returns:
+        str: release without brackets
+    """
     return value.lstrip("[").rstrip("]")
 
 

--- a/keepachangelog/_versioning.py
+++ b/keepachangelog/_versioning.py
@@ -1,3 +1,4 @@
+import logging
 import re
 from functools import cmp_to_key
 from typing import Optional, Iterable
@@ -9,6 +10,8 @@ initial_semantic_version = {
     "prerelease": None,
     "buildmetadata": None,
 }
+
+logger = logging.getLogger(__name__)
 
 
 class InvalidSemanticVersion(Exception):
@@ -160,6 +163,13 @@ semantic_versioning = re.compile(
 def to_semantic(version: Optional[str]) -> dict:
     if not version:
         return initial_semantic_version.copy()
+
+    # handle common 'v' prefix
+    if version.startswith("v"):
+        logger.info(
+            f"Removing 'v' prefix from '{version}' to make it pure SemVer compliant."
+        )
+        version = version[1:]
 
     match = semantic_versioning.fullmatch(version)
     if match:

--- a/tests/test_changelog_prefixed_version.py
+++ b/tests/test_changelog_prefixed_version.py
@@ -1,0 +1,70 @@
+import os
+import os.path
+
+import pytest
+
+import keepachangelog
+
+
+@pytest.fixture
+def changelog(tmpdir):
+    changelog_file_path = os.path.join(tmpdir, "CHANGELOG.md")
+    with open(changelog_file_path, "wt") as file:
+        file.write(
+            """# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [v1.2.3] - 2018-06-01
+
+### Changed
+- Release note 1.
+- Release note 2.
+
+### Fixed
+- Bug fix 1
+- sub bug 1
+- sub bug 2
+- Bug fix 2
+
+### Security
+- Known issue 1
+- Known issue 2
+
+### Deprecated
+- Deprecated feature 1
+- Future removal 2
+
+### Removed
+- Deprecated feature 2
+- Future removal 1
+"""
+        )
+    return changelog_file_path
+
+
+def test_changelog_with_empty_version(changelog):
+    assert keepachangelog.to_dict(changelog) == {
+        "v1.2.3": {
+            "changed": ["Release note 1.", "Release note 2."],
+            "deprecated": ["Deprecated feature 1", "Future removal 2"],
+            "fixed": ["Bug fix 1", "sub bug 1", "sub bug 2", "Bug fix 2"],
+            "removed": ["Deprecated feature 2", "Future removal 1"],
+            "security": ["Known issue 1", "Known issue 2"],
+            "metadata": {
+                "release_date": "2018-06-01",
+                "version": "v1.2.3",
+                "semantic_version": {
+                    "buildmetadata": None,
+                    "major": 1,
+                    "minor": 2,
+                    "patch": 3,
+                    "prerelease": None,
+                },
+            },
+        },
+    }


### PR DESCRIPTION
The `v` prefix is a common pattern. In this PR, I propose to remove it on the fly when it's present to give it a chance to fill the `metadata.semantic_version` attribute.

I also add some minor log messages (I use the lib as a Python package and not as CLI).

https://github.com/opengisch/qgis-plugin-ci/issues/68

Funded by Oslandia.

<!-- osl:grant-oss-2026 -->